### PR TITLE
Format numbers with commas and two decimal places

### DIFF
--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -21,7 +21,7 @@ import StakeConfirm from '../staking/StakeConfirm';
 import { calculateFutureDateMonths } from '@lib/utils/general'
 import { StakePoolResponse, coinectaSyncApi } from '@server/services/syncApi';
 import { metadataApi } from '@server/services/metadataApi';
-import { formatTokenWithDecimals } from '@lib/utils/assets';
+import { formatTokenWithDecimals, formatNumberWithCommasAndRound } from '@lib/utils/assets';
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import { trpc } from '@lib/utils/trpc';
@@ -67,6 +67,7 @@ const AddStakePage: FC = () => {
   const [openConfirmationDialog, setOpenConfirmationDialog] = useState(false);
   const [isStakeTransactionSubmitted, setIsStakeTransactionSubmitted] = useState<boolean>(false);
   const [isStakeTransactionFailed, setIsStakeTransactionFailed] = useState<boolean>(false);
+
 
   const getStakePoolQuery = trpc.sync.getStakePool.useQuery({
     address: STAKE_POOL_VALIDATOR_ADDRESS,
@@ -217,7 +218,7 @@ const AddStakePage: FC = () => {
             />
             <DataSpread
               title="Rewards"
-              data={`${rewards.toLocaleString(undefined, { maximumFractionDigits: 1 })} CNCT`}
+              data={`${formatNumberWithCommasAndRound(parseFloat(rewards.toLocaleString(undefined, { maximumFractionDigits: 1 })))} CNCT`}
               isLoading={isLoading}
             />
             <DataSpread

--- a/src/lib/utils/assets.ts
+++ b/src/lib/utils/assets.ts
@@ -12,7 +12,7 @@ export const formatTokenWithDecimals = (amount: bigint, decimals: number): strin
   const indexToInsertDecimal = amountStr.length - decimals;
   const formattedAmountStr = amountStr.substring(0, indexToInsertDecimal) + '.' + amountStr.substring(indexToInsertDecimal);
   const resultStr = formattedAmountStr.replace(/^0+/, '');
-  return resultStr;
+  return formatNumberWithCommasAndRound(parseFloat(resultStr));
 }
 
 export const parseTokenFromString = (formattedAmount: string, decimals: number): bigint => {
@@ -26,4 +26,12 @@ export const parseTokenFromString = (formattedAmount: string, decimals: number):
   }
 
   return BigInt(amountStr);
+}
+
+export const formatNumberWithCommasAndRound = (num: number): string => {
+  const formatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return formatter.format(num);
 }


### PR DESCRIPTION
This commit implements number formatting for displayed values on the website. Numbers are now formatted with commas as thousands separators and rounded off to two decimal places for improved readability.

Before:
![before-table](https://github.com/coinecta/coinecta-frontend/assets/81457844/e0f30624-a8d1-4dd7-b61c-5d7dbf28d7a3)
![before-no-comma](https://github.com/coinecta/coinecta-frontend/assets/81457844/48108588-bfb8-4a30-bc3e-7fe981c3db85)

After:
![redeem-table](https://github.com/coinecta/coinecta-frontend/assets/81457844/e62399d7-eb99-4d01-bc84-6dca7eaed89e)
![number-commas](https://github.com/coinecta/coinecta-frontend/assets/81457844/183dba3b-37d7-4b1c-a7b4-2da2abdd0166)

This PR closes issue #59 