### PR TITLE
feat: Multi Wallet Redeem Support

### DIFF
--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -78,7 +78,6 @@ const SortByWalletDropdown = ({
         }}
       >
         {connectedWallets.map((connectedWallet) => {
-
           const walletData = walletsList.find(w => w.connectName === connectedWallet);
           const icon = theme.palette.mode === 'dark' ? walletData?.iconDark : walletData?.icon;
           return (
@@ -94,18 +93,3 @@ const SortByWalletDropdown = ({
 };
 
 export default SortByWalletDropdown;
-
-const fakeWalletsData = [
-    {
-        name: 'Nami',
-        icon: '/wallets/nami-light.svg',
-    },
-    {
-        name: 'Lace',
-        icon: '/wallets/lace.svg',
-    },
-    {
-        name: 'Eternl',
-        icon: '/wallets/eternl-light.svg',
-    }
-]

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -34,7 +34,7 @@ const SortByWalletDropdown = ({
       <Typography sx={{ fontWeight: 900 }}>Redeem from</Typography>
       <Select
         variant="filled"
-        value={wallet ?? ''}
+        value={wallet && connectedWallets.includes(wallet) ? wallet : ''}
         onChange={handleChange}
         MenuProps={{
           PaperProps: {

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -34,7 +34,7 @@ const SortByWalletDropdown = ({
       <Typography sx={{ fontWeight: 900 }}>Redeem from</Typography>
       <Select
         variant="filled"
-        value={wallet}
+        value={wallet ?? ''}
         onChange={handleChange}
         MenuProps={{
           PaperProps: {

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import {
+  Select,
+  MenuItem,
+  FormControl,
+  SelectChangeEvent,
+  useTheme,
+  ListItemText,
+  Avatar,
+  Typography
+} from '@mui/material';
+
+
+const SortByWalletDropdown = () => {
+  const theme = useTheme()
+  const [selectedWallet, setSelectedWallet] = useState<string>(fakeWalletsData[0].name);
+
+  const handleChange = (event: SelectChangeEvent) => {
+    const { target: { value } } = event;
+    setSelectedWallet(value);
+  };
+
+  return (
+    <FormControl sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+      <Typography sx={{ fontWeight: 900 }}>Sort by</Typography>
+      <Select
+        variant="filled"
+        value={selectedWallet}
+        onChange={handleChange}
+        MenuProps={{
+          PaperProps: {
+            style: {
+              maxHeight: 420,
+            },
+          }
+        }}
+        sx={{
+          borderRadius: '6px',
+          borderStyle: 'solid',
+          borderWidth: '1px',
+          borderColor: theme.palette.mode === 'dark'
+            ? 'rgba(200, 225, 255, 0.2)'
+            : 'rgba(20, 22, 25, 0.15)',
+          background: theme.palette.mode === 'dark'
+            ? 'radial-gradient(at right top, rgba(16,20,34,0.4), rgba(1, 4, 10, 0.4))'
+            : 'radial-gradient(at right top, rgba(16,20,34,0.05), rgba(1, 4, 10, 0.05))',
+          boxShadow: '2px 2px 5px 3px rgba(0,0,0,0.03)',
+          fontFamily: 'sans-serif',
+          fontSize: '1rem',
+          minWidth: '150px',
+          '& .MuiInputBase-input': {
+            py: '3px',
+            px: '9px',
+          },
+          '&:hover': {
+            borderColor: theme.palette.primary.main,
+          },
+          '& .MuiFilledInput-before': { display: 'none' },
+          '& .MuiFilledInput-after': { display: 'none' },
+          '& .Mui-error': {
+            borderColor: theme.palette.error.dark,
+            borderWidth: '2px'
+          },
+          '& .MuiSelect-select': {
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+          }
+        }}
+      >
+        {fakeWalletsData.map((item) => (
+          <MenuItem key={item.name} value={item.name} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src={item.icon} />
+            <ListItemText primary={item.name} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default SortByWalletDropdown;
+
+const fakeWalletsData = [
+    {
+        name: 'Nami',
+        icon: '/wallets/nami-light.svg',
+    },
+    {
+        name: 'Lace',
+        icon: '/wallets/lace.svg',
+    },
+    {
+        name: 'Eternl',
+        icon: '/wallets/eternl-light.svg',
+    }
+]

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -83,7 +83,7 @@ const SortByWalletDropdown = ({
           return (
             <MenuItem key={connectedWallet} value={connectedWallet} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src={icon} />
-              <ListItemText primary={connectedWallet} />
+              <ListItemText primary={connectedWallet[0].toUpperCase() + connectedWallet.slice(1).toLowerCase()} />
             </MenuItem>
           );
         })}

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -1,23 +1,32 @@
-import React, { useState } from 'react';
+import { walletsList } from '@lib/walletsList';
 import {
-  Select,
-  MenuItem,
-  FormControl,
-  SelectChangeEvent,
-  useTheme,
-  ListItemText,
   Avatar,
-  Typography
+  FormControl,
+  ListItemText,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+  useTheme
 } from '@mui/material';
 
+interface SortByWalletDropdownProps {
+  wallet: string;
+  connectedWallets: string[];
+  setWallet: (wallet: string) => void;
+}
 
-const SortByWalletDropdown = () => {
+const SortByWalletDropdown = ({
+  wallet,
+  setWallet,
+  connectedWallets
+}: SortByWalletDropdownProps) => {
   const theme = useTheme()
-  const [selectedWallet, setSelectedWallet] = useState<string>(fakeWalletsData[0].name);
 
   const handleChange = (event: SelectChangeEvent) => {
     const { target: { value } } = event;
-    setSelectedWallet(value);
+    if (wallet === value) return;
+    setWallet(value);
   };
 
   return (
@@ -25,7 +34,7 @@ const SortByWalletDropdown = () => {
       <Typography sx={{ fontWeight: 900 }}>Sort by</Typography>
       <Select
         variant="filled"
-        value={selectedWallet}
+        value={wallet}
         onChange={handleChange}
         MenuProps={{
           PaperProps: {
@@ -68,12 +77,17 @@ const SortByWalletDropdown = () => {
           }
         }}
       >
-        {fakeWalletsData.map((item) => (
-          <MenuItem key={item.name} value={item.name} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src={item.icon} />
-            <ListItemText primary={item.name} />
-          </MenuItem>
-        ))}
+        {connectedWallets.map((connectedWallet) => {
+
+          const walletData = walletsList.find(w => w.connectName === connectedWallet);
+          const icon = theme.palette.mode === 'dark' ? walletData?.iconDark : walletData?.icon;
+          return (
+            <MenuItem key={connectedWallet} value={connectedWallet} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src={icon} />
+              <ListItemText primary={connectedWallet} />
+            </MenuItem>
+          );
+        })}
       </Select>
     </FormControl>
   );

--- a/src/components/SortByWalletDropdown.tsx
+++ b/src/components/SortByWalletDropdown.tsx
@@ -31,7 +31,7 @@ const SortByWalletDropdown = ({
 
   return (
     <FormControl sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 2 }}>
-      <Typography sx={{ fontWeight: 900 }}>Sort by</Typography>
+      <Typography sx={{ fontWeight: 900 }}>Redeem from</Typography>
       <Select
         variant="filled"
         value={wallet}

--- a/src/components/WalletSelectDropdown.tsx
+++ b/src/components/WalletSelectDropdown.tsx
@@ -24,12 +24,14 @@ const WalletSelectDropdown = () => {
 
   const theme = useTheme()
   const router = useRouter()
-  const { isWalletConnected: _isWalletConnected, setSelectedAddresses, getSelectedAddresses } = useCardano()
+  const { isWalletConnected: _isWalletConnected, setSelectedAddresses: _setSelectedAddresses, getSelectedAddresses: _getSelectedAddresses } = useCardano()
   const [walletAddresses, setWalletAddresses] = useState<string[]>([])
   const [selectedAddresses, setSelectedAddress] = useState<string[]>([])
   const [isConnectedByWallets, setIsConnectedByWallets] = useState<Record<string, boolean>>({})
 
-  const isWalletConnected = useCallback(_isWalletConnected, [_isWalletConnected])
+  const isWalletConnected = useCallback(_isWalletConnected, [_isWalletConnected]);
+  const setSelectedAddresses = useCallback(_setSelectedAddresses, [_setSelectedAddresses]);
+  const getSelectedAddresses = useCallback(_getSelectedAddresses, [_getSelectedAddresses]);
 
   const getWallets = trpc.user.getWallets.useQuery()
 
@@ -46,7 +48,7 @@ const WalletSelectDropdown = () => {
       }
       setWalletAddresses(wallets.map((wallet) => wallet.changeAddress))
     }
-  }, [walletAddresses.length, wallets])
+  }, [getSelectedAddresses, setSelectedAddresses, walletAddresses.length, wallets])
 
   const walletByName = useCallback((name: string) => walletDataByName(name), []);
 
@@ -78,7 +80,7 @@ const WalletSelectDropdown = () => {
       }
     };
     execute();
-  }, [wallets]);
+  }, [isWalletConnected, wallets]);
 
   return (
     <FormControl fullWidth>

--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -1,12 +1,8 @@
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import {
-  Alert,
   Box,
   Button,
-  Divider,
-  Paper,
   Skeleton,
-  Snackbar,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -16,14 +12,9 @@ import StakeInput from '@components/dashboard/staking/StakeInput';
 import StakeDuration from '../staking/StakeDuration';
 import DataSpread from '@components/DataSpread';
 import DashboardHeader from '../DashboardHeader';
-import { useWallet } from '@meshsdk/react';
 import StakeConfirm from '../staking/StakeConfirm';
 import { calculateFutureDateMonths } from '@lib/utils/general'
-import { StakePoolResponse, coinectaSyncApi } from '@server/services/syncApi';
-import { metadataApi } from '@server/services/metadataApi';
 import { formatTokenWithDecimals, formatNumber } from '@lib/utils/assets';
-import TaskAltIcon from '@mui/icons-material/TaskAlt';
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import { trpc } from '@lib/utils/trpc';
 
 const options = [
@@ -52,8 +43,6 @@ const calculateAPY = (lockupMonths: number, interestRate: number): number => {
 }
 
 const AddStakePage: FC = () => {
-  const theme = useTheme()
-
   const STAKE_POOL_VALIDATOR_ADDRESS = process.env.STAKE_POOL_VALIDATOR_ADDRESS!;
   const STAKE_POOL_OWNER_KEY_HASH = process.env.STAKE_POOL_OWNER_KEY_HASH!;
   const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY!;
@@ -65,9 +54,6 @@ const AddStakePage: FC = () => {
   const [durations, setDurations] = useState<number[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [openConfirmationDialog, setOpenConfirmationDialog] = useState(false);
-  const [isStakeTransactionSubmitted, setIsStakeTransactionSubmitted] = useState<boolean>(false);
-  const [isStakeTransactionFailed, setIsStakeTransactionFailed] = useState<boolean>(false);
-
 
   const getStakePoolQuery = trpc.sync.getStakePool.useQuery({
     address: STAKE_POOL_VALIDATOR_ADDRESS,
@@ -110,11 +96,6 @@ const AddStakePage: FC = () => {
     }
   };
 
-  const handleTransactionSubmitted = () => setIsStakeTransactionSubmitted(true);
-  const handleTransactionFailed = () => setIsStakeTransactionFailed(true);
-  const handleSuccessSnackbarClose = () => setIsStakeTransactionSubmitted(false);
-  const handleFailedSnackbarClose = () => setIsStakeTransactionFailed(false);
-
   const total = (Number(cnctAmount) ? (Number(cnctAmount) * (options.find(option => option.duration === stakeDuration)?.interest || 0)) + Number(cnctAmount) : 0).toLocaleString(undefined, { maximumFractionDigits: 1 })
   const rewards = (Number(cnctAmount) ? Number(cnctAmount) * (options.find(option => option.duration === stakeDuration)?.interest || 0) : 0)
 
@@ -148,7 +129,6 @@ const AddStakePage: FC = () => {
               <Button
                 variant="contained"
                 color="secondary"
-                // disabled={!termsCheck || !whitelisted || !live}
                 sx={{
                   textTransform: 'none',
                   fontSize: '20px',
@@ -241,31 +221,7 @@ const AddStakePage: FC = () => {
         duration={stakeDuration}
         total={total}
         rewardIndex={rewardSettingIndex}
-        onTransactionSubmitted={handleTransactionSubmitted}
-        onTransactionFailed={handleTransactionFailed}
       />
-      <Snackbar open={isStakeTransactionSubmitted} autoHideDuration={6000} onClose={handleSuccessSnackbarClose}>
-        <Alert
-          onClose={handleSuccessSnackbarClose}
-          severity="success"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<TaskAltIcon fontSize='medium' />}
-        >
-          Stake transaction submitted
-        </Alert>
-      </Snackbar>
-      <Snackbar open={isStakeTransactionFailed} autoHideDuration={6000} onClose={handleFailedSnackbarClose}>
-        <Alert
-          onClose={handleFailedSnackbarClose}
-          severity="error"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<ErrorOutlineOutlinedIcon fontSize='medium' />}
-        >
-          Error adding stake!
-        </Alert>
-      </Snackbar>
     </Box >
   );
 };

--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -38,11 +38,10 @@ const Dashboard: FC = () => {
 
   const queryStakeSummary = trpc.sync.getStakeSummary.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
 
-  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY!;
-  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME!;
+  const STAKE_POOL_SUBJECT = process.env.STAKE_POOL_ASSET_POLICY! + process.env.STAKE_POOL_ASSET_NAME!;
 
   const summary = useMemo(() => {
-    if (queryStakeSummary.data?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME] === undefined) return undefined;
+    if (queryStakeSummary.data?.poolStats[STAKE_POOL_SUBJECT] === undefined) return undefined;
     return queryStakeSummary.data;
   }, [queryStakeSummary.data]);
 
@@ -109,8 +108,8 @@ const Dashboard: FC = () => {
                 </> :
                 <>
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>
                 </>
               }
@@ -121,8 +120,8 @@ const Dashboard: FC = () => {
           <DashboardCard center>
             <DataSpread
               title="CNCT"
-              data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), '')}
-              usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}`}
+              data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), '')}
+              usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}`}
               isLoading={isLoading}
             />
           </DashboardCard>
@@ -157,8 +156,8 @@ const Dashboard: FC = () => {
                     <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalStaked ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalStaked ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </Box>
               <Divider orientation='vertical' variant='middle' flexItem />
@@ -170,8 +169,8 @@ const Dashboard: FC = () => {
                     <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].unclaimedTokens ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </Box>
             </Box>

--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -38,10 +38,14 @@ const Dashboard: FC = () => {
 
   const queryStakeSummary = trpc.sync.getStakeSummary.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
 
+  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY!;
+  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME!;
+
   const summary = useMemo(() => {
-    if (queryStakeSummary.data?.poolStats.CNCT === undefined) return undefined;
+    if (queryStakeSummary.data?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME] === undefined) return undefined;
     return queryStakeSummary.data;
   }, [queryStakeSummary.data]);
+
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess && !isStakingKeysLoaded);
   }, [isStakingKeysLoaded, queryStakeSummary.isSuccess]);
@@ -105,8 +109,8 @@ const Dashboard: FC = () => {
                 </> :
                 <>
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>
                 </>
               }
@@ -117,8 +121,8 @@ const Dashboard: FC = () => {
           <DashboardCard center>
             <DataSpread
               title="CNCT"
-              data={formatNumber(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), '')}
-              usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), "CNCT"), '')}`}
+              data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), '')}
+              usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}`}
               isLoading={isLoading}
             />
           </DashboardCard>
@@ -153,8 +157,8 @@ const Dashboard: FC = () => {
                     <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT.totalStaked ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.totalStaked ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalStaked ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalStaked ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </Box>
               <Divider orientation='vertical' variant='middle' flexItem />
@@ -166,8 +170,8 @@ const Dashboard: FC = () => {
                     <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT.unclaimedTokens ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].unclaimedTokens ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </Box>
             </Box>

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -60,8 +60,8 @@ const StakePositions: FC = () => {
   const queryStakePositions = trpc.sync.getStakePositions.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const positions = useMemo(() => queryStakePositions.data ?? [], [queryStakePositions.data]);
 
-  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY;
-  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME;
+  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY!;
+  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME!;
 
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded || !queryStakePositions.isSuccess);
@@ -256,8 +256,8 @@ const StakePositions: FC = () => {
                     <Skeleton animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </>
               )
@@ -277,8 +277,8 @@ const StakePositions: FC = () => {
               <DataSpread
                 title="CNCT"
                 margin={0} // last item needs margin 0, the rest don't include the margin prop
-                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), '')}
-                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), "CNCT"), '')}`}
+                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}`}
                 isLoading={isLoading}
               />
             }

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material';
 import Grid from '@mui/system/Unstable_Grid/Grid';
 import { ClaimStakeRequest } from '@server/services/syncApi';
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { IActionBarButton } from '../ActionBar';
 import DashboardCard from '../DashboardCard';
 import DashboardHeader from '../DashboardHeader';
@@ -47,7 +47,9 @@ const StakePositions: FC = () => {
   const [isStakingKeysLoaded, setIsStakingKeysLoaded] = useState(false);
   const [changeAddress, setChangeAddress] = useState<string | undefined>(undefined);
   const { selectedAddresses } = useWalletContext();
-  const { isWalletConnected } = useCardano();
+  const { isWalletConnected: _isWalletConnected } = useCardano();
+
+  const isWalletConnected = useCallback(_isWalletConnected, [_isWalletConnected]);
 
   const getWallets = trpc.user.getWallets.useQuery()
   const userWallets = useMemo(() => getWallets.data && getWallets.data.wallets, [getWallets]);
@@ -197,7 +199,7 @@ const StakePositions: FC = () => {
       }
     };
     execute();
-  }, [wallet, connected, time, userWallets, selectedAddresses, addAlert]);
+  }, [wallet, connected, time, userWallets, selectedAddresses, addAlert, isWalletConnected]);
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
 

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -192,7 +192,7 @@ const StakePositions: FC = () => {
             });
             return processedStakeKeys;
           } catch {
-            addAlert('error', `Failed to load stake positions for ${userWallet.type} wallet. Please reload the page.`);
+            addAlert('error', `Failed to load stake positions for ${userWallet.type[0].toUpperCase() + userWallet.type.slice(1)} wallet. Please reload the page.`);
             console.log('Error getting stake keys', userWallet);
           }
         });

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -107,7 +107,7 @@ const StakePositions: FC = () => {
 
     setRedeemRowData(newData);
   }, [selectedRows, redeemableRows, positions])
-
+  
   useEffect(() => {
     const newRedeemableRows = new Set<number>();
     const newLockedRows = new Set<number>();
@@ -204,7 +204,7 @@ const StakePositions: FC = () => {
   }, [wallet, connected, time, userWallets, selectedAddresses, isWalletConnected]);
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
-
+  
   const claimStakeRequest = useMemo(() => {
     return {
       stakeUtxoOutputReferences: selectedPositions.map((position) => {
@@ -293,7 +293,7 @@ const StakePositions: FC = () => {
       <StakePositionTable
         error={false}
         data={processedPositions.length > 0 ? processedPositions : (isLoading ? fakeTrpcDashboardData.data : [])}
-        connectedWallets={userWallets?.map(uw => uw.type) ?? []}
+        connectedWallets={userWallets?.map(uw => uw.type).filter(w => new Set(Object.values(stakeKeyWalletMapping)).has(w)) ?? []}
         stakeKeyWalletMapping={stakeKeyWalletMapping}
         currentWallet={currentWallet!}
         setCurrentWallet={setCurrentWallet}

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -60,8 +60,7 @@ const StakePositions: FC = () => {
   const queryStakePositions = trpc.sync.getStakePositions.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const positions = useMemo(() => queryStakePositions.data ?? [], [queryStakePositions.data]);
 
-  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY!;
-  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME!;
+  const STAKE_POOL_SUBJECT = process.env.STAKE_POOL_ASSET_POLICY! + process.env.STAKE_POOL_ASSET_NAME!;
 
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded || !queryStakePositions.isSuccess);
@@ -256,8 +255,8 @@ const StakePositions: FC = () => {
                     <Skeleton animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </>
               )
@@ -277,8 +276,8 @@ const StakePositions: FC = () => {
               <DataSpread
                 title="CNCT"
                 margin={0} // last item needs margin 0, the rest don't include the margin prop
-                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), '')}
-                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), "CNCT"), '')}`}
+                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0"), "CNCT"), '')}`}
                 isLoading={isLoading}
               />
             }

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -253,8 +253,8 @@ const StakePositions: FC = () => {
                     <Skeleton animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </>
               )
@@ -274,8 +274,8 @@ const StakePositions: FC = () => {
               <DataSpread
                 title="CNCT"
                 margin={0} // last item needs margin 0, the rest don't include the margin prop
-                data={formatNumber(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), '')}
-                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT.totalPortfolio ?? "0"), "CNCT"), '')}`}
+                data={formatNumber(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), "CNCT"), '')}`}
                 isLoading={isLoading}
               />
             }

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -101,7 +101,7 @@ const StakePositions: FC = () => {
 
     setRedeemRowData(newData);
   }, [selectedRows, redeemableRows, positions])
-  
+
   useEffect(() => {
     const newRedeemableRows = new Set<number>();
     const newLockedRows = new Set<number>();
@@ -144,6 +144,7 @@ const StakePositions: FC = () => {
       if (connected && sessionStatus === 'authenticated') {
         try {
           setWalletUtxosCbor([]);
+          if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
           const api = await window.cardano[walletNameToId(currentWallet!)!].enable();
           const utxos = await api.getUtxos();
           const collateral = api.experimental.getCollateral() === undefined ? [] : await api.experimental.getCollateral();
@@ -196,10 +197,10 @@ const StakePositions: FC = () => {
       }
     };
     execute();
-  }, [wallet, connected, time, userWallets, selectedAddresses, isWalletConnected]);
+  }, [wallet, connected, time, userWallets, selectedAddresses, isWalletConnected, addAlert]);
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
-  
+
   const claimStakeRequest = useMemo(() => {
     return {
       stakeUtxoOutputReferences: selectedPositions.map((position) => {

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -318,7 +318,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: "",
+      unlockDate: new Date(),
       initial: "",
       bonus: "",
       interest: ""
@@ -326,7 +326,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: "",
+      unlockDate: new Date(),
       initial: "",
       bonus: "",
       interest: ""
@@ -334,7 +334,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: "",
+      unlockDate: new Date(),
       initial: "",
       bonus: "",
       interest: ""
@@ -342,7 +342,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: "",
+      unlockDate: new Date(),
       initial: "",
       bonus: "",
       interest: ""
@@ -350,7 +350,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: "",
+      unlockDate: new Date(),
       initial: "",
       bonus: "",
       interest: ""

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -26,6 +26,7 @@ import DashboardHeader from '../DashboardHeader';
 import RedeemConfirm from '../staking/RedeemConfirm';
 import StakePositionTable from '../staking/StakePositionTable';
 import { useCardano } from '@lib/utils/cardano';
+import { useAlert } from '@contexts/AlertContext';
 
 const StakePositions: FC = () => {
   const parentRef = useRef<HTMLDivElement>(null);
@@ -38,6 +39,7 @@ const StakePositions: FC = () => {
   const [isSelectedPositionsEmpty, setIsSelectedPositionsEmpty] = useState(false);
   const [isRedeemSuccessful, setIsRedeemSuccessful] = useState(false);
   const [isRedeemFailed, setIsRedeemFailed] = useState(false);
+  const { addAlert } = useAlert();
 
 
   /* Staking API */
@@ -190,6 +192,7 @@ const StakePositions: FC = () => {
             });
             return processedStakeKeys;
           } catch {
+            addAlert('error', `Failed to load stake positions for ${userWallet.type} wallet. Please reload the page.`);
             console.log('Error getting stake keys', userWallet);
           }
         });

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -199,7 +199,7 @@ const StakePositions: FC = () => {
       }
     };
     execute();
-  }, [wallet, connected, time, userWallets, selectedAddresses, addAlert, isWalletConnected]);
+  }, [wallet, connected, time, userWallets, selectedAddresses]);
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
 

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -60,6 +60,9 @@ const StakePositions: FC = () => {
   const queryStakePositions = trpc.sync.getStakePositions.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const positions = useMemo(() => queryStakePositions.data ?? [], [queryStakePositions.data]);
 
+  const STAKE_POOL_ASSET_POLICY = process.env.STAKE_POOL_ASSET_POLICY;
+  const STAKE_POOL_ASSET_NAME = process.env.STAKE_POOL_ASSET_NAME;
+
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded || !queryStakePositions.isSuccess);
   }, [queryStakeSummary.isSuccess, isStakingKeysLoaded, queryStakePositions.isSuccess]);
@@ -141,16 +144,16 @@ const StakePositions: FC = () => {
 
   useEffect(() => {
     const execute = async () => {
-      if (connected && sessionStatus === 'authenticated') {
+      if (connected && sessionStatus === 'authenticated' && currentWallet) {
         try {
           setWalletUtxosCbor([]);
           if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
           const api = await window.cardano[walletNameToId(currentWallet!)!].enable();
           const utxos = await api.getUtxos();
-          const collateral = api.experimental.getCollateral() === undefined ? [] : await api.experimental.getCollateral();
+          const collateral = await api.experimental.getCollateral() === undefined ? [] : await api.experimental.getCollateral();
           setWalletUtxosCbor([...utxos!, ...collateral!]);
         } catch (ex) {
-          console.log("Error getting utxos", ex);
+          console.error("Error getting utxos", ex);
         }
       }
     };
@@ -159,9 +162,7 @@ const StakePositions: FC = () => {
 
   useEffect(() => {
     const execute = async () => {
-      if (connected) {
-        setChangeAddress(await wallet.getChangeAddress());
-      }
+      if (connected) setChangeAddress(await wallet.getChangeAddress());
     };
     execute();
   }, [connected, wallet]);
@@ -255,8 +256,8 @@ const StakePositions: FC = () => {
                     <Skeleton animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </>
               )
@@ -276,8 +277,8 @@ const StakePositions: FC = () => {
               <DataSpread
                 title="CNCT"
                 margin={0} // last item needs margin 0, the rest don't include the margin prop
-                data={formatNumber(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), '')}
-                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats.CNCT?.totalPortfolio ?? "0"), "CNCT"), '')}`}
+                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY! + STAKE_POOL_ASSET_NAME!]?.totalPortfolio ?? "0"), "CNCT"), '')}`}
                 isLoading={isLoading}
               />
             }
@@ -317,7 +318,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: new Date(),
+      unlockDate: "",
       initial: "",
       bonus: "",
       interest: ""
@@ -325,7 +326,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: new Date(),
+      unlockDate: "",
       initial: "",
       bonus: "",
       interest: ""
@@ -333,7 +334,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: new Date(),
+      unlockDate: "",
       initial: "",
       bonus: "",
       interest: ""
@@ -341,7 +342,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: new Date(),
+      unlockDate: "",
       initial: "",
       bonus: "",
       interest: ""
@@ -349,7 +350,7 @@ const fakeTrpcDashboardData = {
     {
       name: '',
       total: "",
-      unlockDate: new Date(),
+      unlockDate: "",
       initial: "",
       bonus: "",
       interest: ""

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -7,13 +7,9 @@ import { trpc } from '@lib/utils/trpc';
 import { walletNameToId } from '@lib/walletsList';
 import { BrowserWallet } from '@meshsdk/core';
 import { useWallet } from '@meshsdk/react';
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
-import TaskAltIcon from '@mui/icons-material/TaskAlt';
 import {
-  Alert,
   Box,
   Skeleton,
-  Snackbar,
   Typography,
   useTheme
 } from '@mui/material';
@@ -36,11 +32,7 @@ const StakePositions: FC = () => {
   const [openRedeemDialog, setOpenRedeemDialog] = useState(false)
   const [redeemRowData, setRedeemRowData] = useState<IRedeemListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isSelectedPositionsEmpty, setIsSelectedPositionsEmpty] = useState(false);
-  const [isRedeemSuccessful, setIsRedeemSuccessful] = useState(false);
-  const [isRedeemFailed, setIsRedeemFailed] = useState(false);
   const { addAlert } = useAlert();
-
 
   /* Staking API */
   const [stakeKeys, setStakeKeys] = useState<string[]>([]);
@@ -133,7 +125,7 @@ const StakePositions: FC = () => {
 
   const handleRedeem = () => {
     if (selectedPositions.length === 0) {
-      setIsSelectedPositionsEmpty(true);
+      addAlert('error', 'Select the positions to redeem');
       return;
     }
     setOpenRedeemDialog(true);
@@ -236,8 +228,6 @@ const StakePositions: FC = () => {
     },
   ]
 
-  const handleSuccessSnackbarClose = () => setIsRedeemSuccessful(false);
-  const handleFailedSnackbarClose = () => setIsRedeemFailed(false);
   return (
     <Box sx={{ position: 'relative' }} ref={parentRef}>
       <DashboardHeader title="Manage Staked Positions" />
@@ -312,44 +302,7 @@ const StakePositions: FC = () => {
         redeemList={redeemRowData}
         redeemWallet={currentWallet!}
         claimStakeRequest={claimStakeRequest}
-        onRedeemFailed={() => setIsRedeemFailed(true)}
-        onRedeemSuccessful={() => setIsRedeemSuccessful(true)}
       />
-      <Snackbar open={isRedeemSuccessful} autoHideDuration={6000} onClose={handleSuccessSnackbarClose}>
-        <Alert
-          onClose={handleSuccessSnackbarClose}
-          severity="success"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<TaskAltIcon fontSize='medium' />}
-        >
-          Redeem transaction submitted
-        </Alert>
-      </Snackbar>
-      <Snackbar open={isRedeemFailed} autoHideDuration={6000} onClose={handleFailedSnackbarClose}>
-        <Alert
-          onClose={handleFailedSnackbarClose}
-          severity="error"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<ErrorOutlineOutlinedIcon fontSize='medium' />}
-        >
-          Redeem transaction failed
-        </Alert>
-      </Snackbar>
-      {selectedPositions.length === 0 &&
-        <Snackbar open={isSelectedPositionsEmpty} autoHideDuration={6000} onClose={() => setIsSelectedPositionsEmpty(false)}>
-          <Alert
-            onClose={() => setIsSelectedPositionsEmpty(false)}
-            severity="error"
-            variant="outlined"
-            sx={{ width: '100%' }}
-            icon={<ErrorOutlineOutlinedIcon fontSize='medium' />}
-          >
-            Select the positions to redeem
-          </Alert>
-        </Snackbar>
-      }
     </Box>
   );
 };

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -78,7 +78,7 @@ const StakePositions: FC = () => {
   const processedPositions = useMemo(() => {
     return positions.map((position) => {
       return {
-        name: position.name,
+        name: 'CNCT',
         total: formatNumber(parseFloat(formatTokenWithDecimals(BigInt(position.total), cnctDecimals)), ''),
         unlockDate: new Date(position.unlockDate),
         initial: formatNumber(parseFloat(formatTokenWithDecimals(BigInt(position.initial), cnctDecimals)), ''),

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -56,7 +56,7 @@ const StakePositions: FC = () => {
 
   const queryStakeSummary = trpc.sync.getStakeSummary.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const summary = useMemo((() => queryStakeSummary.data), [queryStakeSummary.data]);
-
+  
   const queryStakePositions = trpc.sync.getStakePositions.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const positions = useMemo(() => queryStakePositions.data ?? [], [queryStakePositions.data]);
 
@@ -71,7 +71,7 @@ const StakePositions: FC = () => {
     if (sessionData?.user) {
       setCurrentWallet(sessionData.user.walletType!);
     }
-
+    
   }, [sessionData])
 
   const processedPositions = useMemo(() => {
@@ -125,7 +125,7 @@ const StakePositions: FC = () => {
     setLockedRows(newLockedRows);
 
   }, [processedPositions, selectedRows]);
-
+  
   const handleRedeem = () => {
     if (selectedPositions.length === 0) {
       addAlert('error', 'Select the positions to redeem');
@@ -198,7 +198,7 @@ const StakePositions: FC = () => {
       }
     };
     execute();
-  }, [wallet, connected, time, userWallets, selectedAddresses, isWalletConnected, addAlert]);
+  }, [wallet, connected, time, userWallets, selectedAddresses, addAlert]);
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
 
@@ -256,8 +256,8 @@ const StakePositions: FC = () => {
                     <Skeleton animation='wave' width={100} />
                   </Box> :
                   <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
                   </Box>}
               </>
               )
@@ -277,8 +277,8 @@ const StakePositions: FC = () => {
               <DataSpread
                 title="CNCT"
                 margin={0} // last item needs margin 0, the rest don't include the margin prop
-                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), '')}
-                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME].totalPortfolio ?? "0"), "CNCT"), '')}`}
+                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_ASSET_POLICY + STAKE_POOL_ASSET_NAME]?.totalPortfolio ?? "0"), "CNCT"), '')}`}
                 isLoading={isLoading}
               />
             }

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -149,8 +149,8 @@ const StakePositions: FC = () => {
           if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
           const api = await window.cardano[walletNameToId(currentWallet!)!].enable();
           const utxos = await api.getUtxos();
-          const collateral = await api.experimental.getCollateral() === undefined ? [] : await api.experimental.getCollateral();
-          setWalletUtxosCbor([...utxos!, ...collateral!]);
+          const collateral = api.experimental.getCollateral === undefined ? [] : await api.experimental.getCollateral();
+          setWalletUtxosCbor([...utxos!, ...(collateral ?? [])]);
         } catch (ex) {
           console.error("Error getting utxos", ex);
         }

--- a/src/components/dashboard/pages/TransactionHistoryPage.tsx
+++ b/src/components/dashboard/pages/TransactionHistoryPage.tsx
@@ -1,20 +1,13 @@
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Alert,
-  Box,
-  Snackbar,
-} from '@mui/material';
+import { Box } from '@mui/material';
 import DashboardHeader from '../DashboardHeader';
 import TransactionHistoryTable from '../TransactionHistoryTable';
-import { StakeRequest, StakeRequestsResponse, coinectaSyncApi } from '@server/services/syncApi';
-import { useWallet } from '@meshsdk/react';
+import { StakeRequestsResponse } from '@server/services/syncApi';
 import { formatTokenWithDecimals, formatNumber } from '@lib/utils/assets';
 import { useToken } from '@components/hooks/useToken';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import TaskAltIcon from '@mui/icons-material/TaskAlt';
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import { useWalletContext } from '@contexts/WalletContext';
 import { trpc } from '@lib/utils/trpc';
 
@@ -24,8 +17,6 @@ const TransactionHistory: FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [currentRequestPage, setCurrentRequestPage] = useState<number>(1);
   const [requestPageLimit, setRequestPageLimit] = useState<number>(5);
-  const [isCancellationSuccessful, setIsCancellationSuccessful] = useState<boolean>(false);
-  const [isCancellationFailed, setIsCancellationFailed] = useState<boolean>(false);
   const [stakeRequestResponse, setStakeRequestResponse] = useState<StakeRequestsResponse | null>(null);
   const { selectedAddresses } = useWalletContext();
 
@@ -81,11 +72,6 @@ const TransactionHistory: FC = () => {
     });
   }, [stakeRequestResponse, cnctDecimals]);
 
-  const handleCancellationSuccessful = (status: boolean) => setIsCancellationSuccessful(status);
-  const handleCancellationFailed = (status: boolean) => setIsCancellationFailed(status)
-  const handleSuccessSnackbarClose = () => setIsCancellationSuccessful(false);
-  const handleFailedSnackbarClose = () => setIsCancellationFailed(false);
-
   return (
     <Box ref={parentRef}>
       <DashboardHeader title="Transaction History" />
@@ -101,31 +87,7 @@ const TransactionHistory: FC = () => {
         requestPageLimit={requestPageLimit}
         setCurrentRequestPage={setCurrentRequestPage}
         setRequestPageLimit={setRequestPageLimit}
-        onCancellationSuccessful={handleCancellationSuccessful}
-        onCancellationFailed={handleCancellationFailed}
       />
-      <Snackbar open={isCancellationSuccessful} autoHideDuration={6000} onClose={handleSuccessSnackbarClose}>
-        <Alert
-          onClose={handleSuccessSnackbarClose}
-          severity="success"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<TaskAltIcon fontSize='medium' />}
-        >
-          Cancel transaction submitted
-        </Alert>
-      </Snackbar>
-      <Snackbar open={isCancellationFailed} autoHideDuration={6000} onClose={handleFailedSnackbarClose}>
-        <Alert
-          onClose={handleFailedSnackbarClose}
-          severity="error"
-          variant="outlined"
-          sx={{ width: '100%' }}
-          icon={<ErrorOutlineOutlinedIcon fontSize='medium' />}
-        >
-          Cancel transaction failed
-        </Alert>
-      </Snackbar>
     </Box>
   );
 };

--- a/src/components/dashboard/staking/RedeemConfirm.tsx
+++ b/src/components/dashboard/staking/RedeemConfirm.tsx
@@ -1,30 +1,31 @@
-import React, { FC, useEffect, useState } from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  Typography,
-  DialogActions,
-  useMediaQuery,
-  useTheme,
-  Button,
-  IconButton,
-  CircularProgress,
-} from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
 import DataSpread from '@components/DataSpread';
 import { useToken } from '@components/hooks/useToken';
-import { formatTokenWithDecimals } from '@lib/utils/assets';
-import { useWallet } from '@meshsdk/react';
-import { walletNameToId } from '@lib/walletsList';
 import { useWalletContext } from '@contexts/WalletContext';
-import { ClaimStakeRequest, coinectaSyncApi } from '@server/services/syncApi';
+import { formatTokenWithDecimals } from '@lib/utils/assets';
 import { trpc } from '@lib/utils/trpc';
+import { walletNameToId } from '@lib/walletsList';
+import { useWallet } from '@meshsdk/react';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { ClaimStakeRequest } from '@server/services/syncApi';
+import React, { FC, useEffect, useState } from 'react';
 
 interface IRedeemConfirmProps {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   redeemList: IRedeemListItem[];
+  redeemWallet: string;
   claimStakeRequest: ClaimStakeRequest;
   onRedeemSuccessful: () => void;
   onRedeemFailed: () => void;
@@ -34,6 +35,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   open,
   setOpen,
   redeemList,
+  redeemWallet,
   claimStakeRequest,
   onRedeemSuccessful,
   onRedeemFailed
@@ -53,12 +55,12 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   useEffect(() => {
     const execute = async () => {
       if (connected && sessionStatus === 'authenticated') {
-        const api = await window.cardano[walletNameToId(sessionData?.user.walletType!)!].enable();
+        const api = await window.cardano[walletNameToId(redeemWallet)!].enable();
         setCardanoApi(api);
       }
     };
     execute();
-  }, [connected, sessionData?.user.walletType, sessionStatus]);
+  }, [connected, redeemWallet, sessionStatus]);
 
   const handleClose = () => {
     setOpen(false);

--- a/src/components/dashboard/staking/RedeemConfirm.tsx
+++ b/src/components/dashboard/staking/RedeemConfirm.tsx
@@ -53,6 +53,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   useEffect(() => {
     const execute = async () => {
       if (connected && sessionStatus === 'authenticated' && redeemWallet) {
+        if (window.cardano[walletNameToId(redeemWallet!)!] === undefined) return;
         const api = await window.cardano[walletNameToId(redeemWallet)!].enable();
         setCardanoApi(api);
       }

--- a/src/components/dashboard/staking/RedeemConfirm.tsx
+++ b/src/components/dashboard/staking/RedeemConfirm.tsx
@@ -54,7 +54,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
 
   useEffect(() => {
     const execute = async () => {
-      if (connected && sessionStatus === 'authenticated') {
+      if (connected && sessionStatus === 'authenticated' && redeemWallet) {
         const api = await window.cardano[walletNameToId(redeemWallet)!].enable();
         setCardanoApi(api);
       }

--- a/src/components/dashboard/staking/RedeemConfirm.tsx
+++ b/src/components/dashboard/staking/RedeemConfirm.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import { ClaimStakeRequest } from '@server/services/syncApi';
 import React, { FC, useEffect, useState } from 'react';
+import { useAlert } from '@contexts/AlertContext';
 
 interface IRedeemConfirmProps {
   open: boolean;
@@ -27,8 +28,6 @@ interface IRedeemConfirmProps {
   redeemList: IRedeemListItem[];
   redeemWallet: string;
   claimStakeRequest: ClaimStakeRequest;
-  onRedeemSuccessful: () => void;
-  onRedeemFailed: () => void;
 }
 
 const RedeemConfirm: FC<IRedeemConfirmProps> = ({
@@ -37,8 +36,6 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   redeemList,
   redeemWallet,
   claimStakeRequest,
-  onRedeemSuccessful,
-  onRedeemFailed
 }) => {
   const { cnctDecimals } = useToken();
   const theme = useTheme();
@@ -48,6 +45,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   const { sessionData, sessionStatus } = useWalletContext();
   const [cardanoApi, setCardanoApi] = useState<any>(undefined);
   const [isSigning, setIsSigning] = useState(false);
+  const { addAlert } = useAlert();
 
   const claimStakeTxMutation = trpc.sync.claimStakeTx.useMutation();
   const finalizeTxMutation = trpc.sync.finalizeTx.useMutation();
@@ -62,10 +60,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
     execute();
   }, [connected, redeemWallet, sessionStatus]);
 
-  const handleClose = () => {
-    setOpen(false);
-  };
-
+  const handleClose = () => setOpen(false);
 
   const handleSubmit = async () => {
     try {
@@ -81,11 +76,11 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
 
         await cardanoApi.submitTx(signedTxCbor);
         setOpen(false);
-        onRedeemSuccessful()
+        addAlert('success', 'Redeem transaction submitted');
       }
     } catch (e) {
       console.log(e);
-      onRedeemFailed();
+      addAlert('error', 'Redeem transaction failed');
     }
     setIsSigning(false);
   }

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -71,6 +71,7 @@ const StakePositionTable = <T extends Record<string, any>>({
   const paperRef = useRef<HTMLDivElement>(null);
   const [sortedData, setSortedData] = useState<T[]>(data);
   const [isAllRowsStakedUnderSingleWallet, setIsAllRowsStakedUnderSingleWallet] = useState<boolean>(false);
+  const [isInfoSnackbarShown, setIsInfoSnackbarShown] = useState<boolean>(false);
   const { addAlert } = useAlert();
   const { selectedAddresses } = useWalletContext();
 
@@ -97,9 +98,11 @@ const StakePositionTable = <T extends Record<string, any>>({
   }, [currentWallet, setSelectedRows, selectedAddresses])
 
   useEffect(() => {
-    if (selectedRows?.size === 1)
+    if (selectedRows!.size >= 1 && !isInfoSnackbarShown){
       addAlert('info', 'Please note: You can only redeem rewards using one wallet type at a time.');
-  }, [selectedRows])
+      setIsInfoSnackbarShown(true);
+    }
+  }, [selectedRows, isInfoSnackbarShown])
   
   useEffect(() => {
     data.sort((a, b) => {

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -102,7 +102,7 @@ const StakePositionTable = <T extends Record<string, any>>({
       addAlert('info', 'Please note: You can only redeem rewards using one wallet type at a time.');
       setIsInfoSnackbarShown(true);
     }
-  }, [selectedRows, isInfoSnackbarShown])
+  }, [selectedRows, isInfoSnackbarShown, addAlert])
   
   useEffect(() => {
     data.sort((a, b) => {
@@ -126,7 +126,7 @@ const StakePositionTable = <T extends Record<string, any>>({
     const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
     setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
     if (isAllRowsStakedUnderSingleWallet) setCurrentWallet(stakeKeyWalletMappingValues[stakeKeyWalletMappingValues.length - 1]);
-  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet])  
+  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])  
 
   const isTableWiderThanParent = parentWidth < paperWidth
 
@@ -201,7 +201,7 @@ const StakePositionTable = <T extends Record<string, any>>({
   const unselectableRows = useMemo(() => {
     return selectableRows
       .filter(r => stakeKeyWalletMapping[r.stakeKey] !== currentWallet);
-  }, [selectableRows]);
+  }, [currentWallet, selectableRows, stakeKeyWalletMapping]);
 
   const handleCheckboxClick = (isDisabled: boolean, item: any): void => {
     if (isDisabled && unselectableRows.some(row => row.stakeKey === item.stakeKey))

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -256,7 +256,7 @@ const StakePositionTable = <T extends Record<string, any>>({
         <DashboardCard sx={{ border: 'none', paddingLeft: '0', paddingRight: '0' }}>
           <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', position: 'relative' }}>
             {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
-            <Box sx={{ display: isLoading ? 'none' : 'block', position: 'absolute', top: 0, right: '8px' }}>
+            <Box sx={{ display: data.length === 0 || isLoading ? 'none' : 'block', position: 'absolute', top: '8px', right: '8px' }}>
               {isLoading ?
                 <Skeleton width={100} /> :
                 <SortByWalletDropdown 

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -313,7 +313,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                   {actions && sortedData.length > 0 && selectedRows && <TableCell padding="checkbox">
                     <Checkbox
                       indeterminate={someSelectableSelected}
-                      checked={allSelectableSelected}
+                      checked={Object.keys(stakeKeyWalletMapping).length === 0 ? false : allSelectableSelected}
                       onChange={handleSelectAllRows}
                       color="secondary"
                     />

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -124,9 +124,10 @@ const StakePositionTable = <T extends Record<string, any>>({
 
   useEffect(() => {
     const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
+    if (stakeKeyWalletMappingValues.length === 0) return;
     setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
-    if (isAllRowsStakedUnderSingleWallet) setCurrentWallet(stakeKeyWalletMappingValues[stakeKeyWalletMappingValues.length - 1]);
-  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])  
+    if (isAllRowsStakedUnderSingleWallet) setCurrentWallet(stakeKeyWalletMappingValues[0]);
+  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])
 
   const isTableWiderThanParent = parentWidth < paperWidth
 
@@ -249,7 +250,7 @@ const StakePositionTable = <T extends Record<string, any>>({
 
   const allSelectableSelected = selectableRows.every(item => selectedRows?.has(item));
   const someSelectableSelected = selectableRows.some(item => selectedRows?.has(item)) && !allSelectableSelected;
-  const allRowsIrredeemable = sortedData.every(item => item.unlockDate > new Date());
+  const allRowsIrredeemable = sortedData.every(item => isCheckboxDisabled(item));
 
   if (error) return <div>Error loading</div>;
 
@@ -289,7 +290,7 @@ const StakePositionTable = <T extends Record<string, any>>({
           <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', position: 'relative' }}>
             {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
             <Box sx={{
-                display: isAllRowsStakedUnderSingleWallet || data.length === 0 || isLoading ? 'none' : 'block',
+                display: isAllRowsStakedUnderSingleWallet ||  data.length === 0 || isLoading ? 'none' : 'block',
                 position: 'absolute',
                 top: '8px',
                 right: '8px'

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -122,12 +122,14 @@ const StakePositionTable = <T extends Record<string, any>>({
     setSortedData([...data]);
   }, [data, currentWallet, stakeKeyWalletMapping])
 
-  useEffect(() => {
-    const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
-    if (stakeKeyWalletMappingValues.length === 0) return;
-    setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
-    if (isAllRowsStakedUnderSingleWallet) setCurrentWallet(stakeKeyWalletMappingValues[0]);
-  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])
+  // useEffect(() => {
+  //   const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
+  //   if (stakeKeyWalletMappingValues.length === 0) return;
+  //   setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
+  //   if (isAllRowsStakedUnderSingleWallet) {
+  //     setCurrentWallet(stakeKeyWalletMappingValues[0]);
+  //   }
+  // }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])
 
   const isTableWiderThanParent = parentWidth < paperWidth
 

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -122,14 +122,18 @@ const StakePositionTable = <T extends Record<string, any>>({
     setSortedData([...data]);
   }, [data, currentWallet, stakeKeyWalletMapping])
 
-  // useEffect(() => {
-  //   const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
-  //   if (stakeKeyWalletMappingValues.length === 0) return;
-  //   setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
-  //   if (isAllRowsStakedUnderSingleWallet) {
-  //     setCurrentWallet(stakeKeyWalletMappingValues[0]);
-  //   }
-  // }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet])
+  useEffect(() => {
+    const stakeKeyWalletMappingValues = Object.values(stakeKeyWalletMapping);
+    if (stakeKeyWalletMappingValues.length === 0) return;
+    setIsAllRowsStakedUnderSingleWallet(stakeKeyWalletMappingValues.every(v => v === stakeKeyWalletMappingValues[0]));
+  }, [stakeKeyWalletMapping]);
+
+  useEffect(() => {
+    if (isAllRowsStakedUnderSingleWallet) {
+      setCurrentWallet(Object.values(stakeKeyWalletMapping)[0]);
+    }
+  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet]);
+
 
   const isTableWiderThanParent = parentWidth < paperWidth
 

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -188,8 +188,8 @@ const StakePositionTable = <T extends Record<string, any>>({
   const allSelectableSelected = selectableRows.every(index => selectedRows?.has(index));
   const someSelectableSelected = selectableRows.some(index => selectedRows?.has(index)) && !allSelectableSelected;
 
-  // if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error loading</div>;
+
   return (
     <Box
       ref={tableRef}
@@ -223,9 +223,11 @@ const StakePositionTable = <T extends Record<string, any>>({
           </Typography>
         }
         <DashboardCard sx={{ border: 'none', paddingLeft: '0', paddingRight: '0' }}>
-          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingRight: '8px' }}>
+          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', position: 'relative' }}>
             {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
-            <SortByWalletDropdown />
+            <Box sx={{ display: isLoading ? 'none' : 'block', position: 'absolute', top: 0, right: '8px' }}>
+              {isLoading ? <Skeleton width={100} /> : <SortByWalletDropdown />}
+            </Box>
           </Box>
           {data.length > 0 ?
             <Table>

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -1,5 +1,8 @@
+import SortByWalletDropdown from '@components/SortByWalletDropdown';
 import ActionBar, { IActionBarButton } from '@components/dashboard/ActionBar';
+import { walletsList } from '@lib/walletsList';
 import {
+  Avatar,
   Box,
   Checkbox,
   Paper,
@@ -17,17 +20,19 @@ import {
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import DashboardCard from '../DashboardCard';
-import SortByWalletDropdown from '@components/SortByWalletDropdown';
 
 interface IStakePositionTableProps<T> {
   title?: string;
   data: T[];
-  stakeKeyWalletMapping: Record<string, string>,
+  stakeKeyWalletMapping: Record<string, string>;
+  currentWallet: string;
+  setCurrentWallet: (wallet: string) => void;
+  connectedWallets: string[];
   isLoading: boolean;
   error: boolean;
   actions?: IActionBarButton[];
-  selectedRows?: Set<number>;
-  setSelectedRows?: React.Dispatch<React.SetStateAction<Set<number>>>
+  selectedRows?: Set<T>;
+  setSelectedRows?: React.Dispatch<React.SetStateAction<Set<any>>>
   parentContainerRef: React.RefObject<HTMLDivElement>;
 }
 
@@ -41,7 +46,10 @@ const rowsPerPageOptions = [5, 10, 15];
 const StakePositionTable = <T extends Record<string, any>>({
   title,
   data,
+  currentWallet,
+  setCurrentWallet,
   stakeKeyWalletMapping,
+  connectedWallets,
   isLoading,
   error,
   actions,
@@ -59,6 +67,7 @@ const StakePositionTable = <T extends Record<string, any>>({
   const [rowsPerPage, setRowsPerPage] = useState(rowsPerPageOptions[0]);
   const tableRef = useRef<HTMLDivElement>(null);
   const paperRef = useRef<HTMLDivElement>(null);
+  const [sortedData, setSortedData] = useState<T[]>(data);
 
   const sensitivityThreshold = 2;
 
@@ -75,6 +84,33 @@ const StakePositionTable = <T extends Record<string, any>>({
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
+  useEffect(() => setSortedData(data), [data]);
+
+  useEffect(() => {
+    if (currentWallet)
+    {
+      setSelectedRows!(new Set());
+    }
+  }, [currentWallet, setSelectedRows])
+
+  useEffect(() => {
+    data.sort((a, b) => {
+      // If a's wallet matches currentWallet, it should come before b
+      if (stakeKeyWalletMapping[a.stakeKey] === currentWallet && stakeKeyWalletMapping[b.stakeKey] !== currentWallet) {
+        return -1;
+      }
+      // If b's wallet matches currentWallet, it should come before a
+      if (stakeKeyWalletMapping[b.stakeKey] === currentWallet && stakeKeyWalletMapping[a.stakeKey] !== currentWallet) {
+        return 1;
+      }
+      
+      // If neither a nor b is the currentWallet, keep their original order
+      return 0;
+    });
+
+    setSortedData([...data]);
+  }, [data, currentWallet, stakeKeyWalletMapping])
 
   const isTableWiderThanParent = parentWidth < paperWidth
 
@@ -122,7 +158,7 @@ const StakePositionTable = <T extends Record<string, any>>({
   const onTouchEnd = () => onDragEnd();
 
   const theme = useTheme();
-  const columns: (keyof T)[] = data.length > 0 ? Object.keys(data[0]) as (keyof T)[] : [];
+  const columns: (keyof T)[] = sortedData.length > 0 ? Object.keys(sortedData[0]) as (keyof T)[] : [];
 
   const renderCellContent = (item: T, key: keyof T) => {
     const cellData = item[key];
@@ -142,20 +178,20 @@ const StakePositionTable = <T extends Record<string, any>>({
   };
 
   const selectableRows = useMemo(() => {
-    return data.map((d, index) => ({ index, unlockDate: d.unlockDate })).filter(d => d.unlockDate < new Date()).map(d => d.index);
-  }, [data]);
+    return sortedData
+      .filter(d => d.unlockDate < new Date());
+  }, [sortedData]);
 
-  const handleSelectRow = (index: number) => {
+  const handleSelectRow = (item: T) => {
     if (setSelectedRows && actions) {
       setSelectedRows((prevSelectedRows) => {
         const newSelectedRows = new Set(prevSelectedRows);
-        const currentItem = data[index];
         // Check if the checkbox for this row is not disabled
-        if (!isCheckboxDisabled(currentItem)) {
-          if (newSelectedRows.has(index)) {
-            newSelectedRows.delete(index);
+        if (!isCheckboxDisabled(item)) {
+          if (newSelectedRows.has(item)) {
+            newSelectedRows.delete(item);
           } else {
-            newSelectedRows.add(index);
+            newSelectedRows.add(item);
           }
         }
         return newSelectedRows;
@@ -163,15 +199,11 @@ const StakePositionTable = <T extends Record<string, any>>({
     }
   };
 
-  const handleSelectAllRows = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSelectAllRows = () => {
     if (setSelectedRows && actions) {
-      const newSelectedRows = new Set([] as number[]);
-      if (event.target.checked) {
-        selectableRows.forEach(index => newSelectedRows.add(index));
-      } else {
-        selectableRows.forEach(index => newSelectedRows.delete(index));
-      }
-      setSelectedRows(newSelectedRows);
+      sortedData
+        .filter(item => stakeKeyWalletMapping[item.stakeKey] == currentWallet && !isCheckboxDisabled(item))
+        .forEach((item) => handleSelectRow(item));
     }
   };
 
@@ -184,8 +216,8 @@ const StakePositionTable = <T extends Record<string, any>>({
     setPage(0);
   };
 
-  const allSelectableSelected = selectableRows.every(index => selectedRows?.has(index));
-  const someSelectableSelected = selectableRows.some(index => selectedRows?.has(index)) && !allSelectableSelected;
+  const allSelectableSelected = selectableRows.every(item => selectedRows?.has(item));
+  const someSelectableSelected = selectableRows.some(item => selectedRows?.has(item)) && !allSelectableSelected;
 
   // if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error loading</div>;
@@ -223,10 +255,13 @@ const StakePositionTable = <T extends Record<string, any>>({
         }
         <DashboardCard sx={{ border: 'none', paddingLeft: '0', paddingRight: '0' }}>
           <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingRight: '8px' }}>
-            {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
-            <SortByWalletDropdown />
+            {actions && sortedData.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
+            <SortByWalletDropdown 
+              wallet={currentWallet} 
+              setWallet={setCurrentWallet} 
+              connectedWallets={connectedWallets} />
           </Box>
-          {data.length > 0 ?
+          {sortedData.length > 0 ?
             <Table>
               <TableHead>
                 <TableRow sx={{
@@ -238,7 +273,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                   }
                 }}>
                   <TableCell></TableCell>
-                  {actions && data.length > 0 && selectedRows && <TableCell padding="checkbox">
+                  {actions && sortedData.length > 0 && selectedRows && <TableCell padding="checkbox">
                     <Checkbox
                       indeterminate={someSelectableSelected}
                       checked={allSelectableSelected}
@@ -248,16 +283,19 @@ const StakePositionTable = <T extends Record<string, any>>({
                   </TableCell>}
 
                   {columns.map((column) => (
-                    <TableCell key={String(column)}>
-                      {camelCaseToTitle(String(column))}
-                    </TableCell>
+                    column !== 'stakeKey' && 
+                    <TableCell key={String(column)}> {camelCaseToTitle(String(column))} </TableCell>
                   ))}
                 </TableRow>
               </TableHead>
               <TableBody>
-                {data.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((item, index) => {
+                {sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((item, index) => {
                   const itemIndex = page * rowsPerPage + index;
-                  return (
+                  const walletType = stakeKeyWalletMapping[item.stakeKey];
+                  const wallet = walletsList.find(w => w.connectName === walletType);
+                  const icon = theme.palette.mode === 'dark' ? wallet?.iconDark : wallet?.icon;
+
+                  return ( 
                     <TableRow key={itemIndex}
                       sx={{
                         '&:nth-of-type(odd)': { backgroundColor: theme.palette.mode === 'dark' ? 'rgba(205,205,235,0.05)' : 'rgba(0,0,0,0.05)' },
@@ -265,17 +303,18 @@ const StakePositionTable = <T extends Record<string, any>>({
                       }}
                     >
                       <TableCell sx={{ borderBottom: 'none', width: '22px' }}>
-                        <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src="/wallets/nami-light.svg" />
+                        <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src={icon} />
                       </TableCell>
                       {actions && selectedRows && <TableCell padding="checkbox" sx={{ borderBottom: 'none' }}>
                         <Checkbox
-                          checked={selectedRows.has(itemIndex)}
-                          onChange={() => handleSelectRow(itemIndex)}
+                          checked={selectedRows.has(item)}
+                          onChange={() => handleSelectRow(item)}
                           color="secondary"
-                          disabled={item.unlockDate > new Date()}
+                          disabled={item.unlockDate > new Date() || stakeKeyWalletMapping[item.stakeKey] !== currentWallet}
                         />
                       </TableCell>}
                       {Object.keys(item).map((key, colIndex) => (
+                        key !== 'stakeKey' && 
                         <TableCell key={`${key}-${colIndex}`} sx={{ borderBottom: 'none' }}>
                           {isLoading ? <Skeleton width={100} /> : renderCellContent(item, key)}
                         </TableCell>
@@ -290,7 +329,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                     component="td"
                     rowsPerPageOptions={rowsPerPageOptions}
                     colSpan={8}
-                    count={data.length}
+                    count={sortedData.length}
                     rowsPerPage={rowsPerPage}
                     page={page}
                     onPageChange={handleChangePage}

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -1,15 +1,12 @@
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import ActionBar, { IActionBarButton } from '@components/dashboard/ActionBar';
 import {
-  Avatar,
   Box,
-  Button,
   Checkbox,
   Paper,
   Skeleton,
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableFooter,
   TableHead,
   TablePagination,
@@ -18,12 +15,13 @@ import {
   useTheme
 } from '@mui/material';
 import dayjs from 'dayjs';
-import ActionBar, { IActionBarButton } from '@components/dashboard/ActionBar';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import DashboardCard from '../DashboardCard';
 
 interface IStakePositionTableProps<T> {
   title?: string;
   data: T[];
+  stakeKeyWalletMapping: Record<string, string>,
   isLoading: boolean;
   error: boolean;
   actions?: IActionBarButton[];
@@ -42,6 +40,7 @@ const rowsPerPageOptions = [5, 10, 15];
 const StakePositionTable = <T extends Record<string, any>>({
   title,
   data,
+  stakeKeyWalletMapping,
   isLoading,
   error,
   actions,

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -20,6 +20,7 @@ import {
 import dayjs from 'dayjs';
 import ActionBar, { IActionBarButton } from '@components/dashboard/ActionBar';
 import DashboardCard from '../DashboardCard';
+import SortByWalletDropdown from '@components/SortByWalletDropdown';
 
 interface IStakePositionTableProps<T> {
   title?: string;
@@ -222,7 +223,10 @@ const StakePositionTable = <T extends Record<string, any>>({
           </Typography>
         }
         <DashboardCard sx={{ border: 'none', paddingLeft: '0', paddingRight: '0' }}>
-          {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
+          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingRight: '8px' }}>
+            {actions && data.length > 0 && <ActionBar isDisabled={isLoading} actions={actions} />}
+            <SortByWalletDropdown />
+          </Box>
           {data.length > 0 ?
             <Table>
               <TableHead>
@@ -234,6 +238,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                     background: theme.palette.background.paper,
                   }
                 }}>
+                  <TableCell></TableCell>
                   {actions && data.length > 0 && selectedRows && <TableCell padding="checkbox">
                     <Checkbox
                       indeterminate={someSelectableSelected}
@@ -260,6 +265,9 @@ const StakePositionTable = <T extends Record<string, any>>({
                         '&:hover': { background: theme.palette.mode === 'dark' ? 'rgba(205,205,235,0.15)' : 'rgba(0,0,0,0.1)' }
                       }}
                     >
+                      <TableCell sx={{ borderBottom: 'none', width: '22px' }}>
+                        <Avatar variant='square' sx={{ width: '22px', height: '22px' }} src="/wallets/nami-light.svg" />
+                      </TableCell>
                       {actions && selectedRows && <TableCell padding="checkbox" sx={{ borderBottom: 'none' }}>
                         <Checkbox
                           checked={selectedRows.has(itemIndex)}
@@ -282,7 +290,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                   <TablePagination
                     component="td"
                     rowsPerPageOptions={rowsPerPageOptions}
-                    colSpan={7}
+                    colSpan={8}
                     count={data.length}
                     rowsPerPage={rowsPerPage}
                     page={page}

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -190,9 +190,7 @@ const StakePositionTable = <T extends Record<string, any>>({
     }
   };
 
-  const isCheckboxDisabled = (item: T) => {
-    return item.unlockDate > new Date();
-  };
+  const isCheckboxDisabled = (item: T) => item.unlockDate > new Date();
 
   const selectableRows = useMemo(() => {
     return sortedData
@@ -352,7 +350,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                             checked={selectedRows.has(item)}
                             onChange={() => handleSelectRow(item)}
                             color="secondary"
-                            disabled={item.unlockDate > new Date() || stakeKeyWalletMapping[item.stakeKey] !== currentWallet}
+                            disabled={isCheckboxDisabled(item) || stakeKeyWalletMapping[item.stakeKey] !== currentWallet}
                           />
                         </Box>
                       </TableCell>}

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -212,7 +212,7 @@ const StakePositionTable = <T extends Record<string, any>>({
         // Check if the checkbox for this row is not disabled
         if (!isCheckboxDisabled(item)) {
           if (newSelectedRows.has(item)) {
-            newSelectedRows.delete(item);
+            newSelectedRows.delete(item);  
           } else {
             newSelectedRows.add(item);
           }
@@ -223,6 +223,11 @@ const StakePositionTable = <T extends Record<string, any>>({
   };
 
   const handleSelectAllRows = () => {
+    if (selectedRows!.size >= 1) {
+      setSelectedRows!(new Set());
+      return;
+    }
+
     if (setSelectedRows && actions) {
       sortedData
         .filter(item => stakeKeyWalletMapping[item.stakeKey] == currentWallet && !isCheckboxDisabled(item))

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -249,6 +249,7 @@ const StakePositionTable = <T extends Record<string, any>>({
 
   const allSelectableSelected = selectableRows.every(item => selectedRows?.has(item));
   const someSelectableSelected = selectableRows.some(item => selectedRows?.has(item)) && !allSelectableSelected;
+  const allRowsIrredeemable = sortedData.every(item => item.unlockDate > new Date());
 
   if (error) return <div>Error loading</div>;
 
@@ -316,7 +317,7 @@ const StakePositionTable = <T extends Record<string, any>>({
                   {actions && sortedData.length > 0 && selectedRows && <TableCell padding="checkbox">
                     <Checkbox
                       indeterminate={someSelectableSelected}
-                      checked={Object.keys(stakeKeyWalletMapping).length === 0 ? false : allSelectableSelected}
+                      checked={Object.keys(stakeKeyWalletMapping).length === 0 ? false : (allSelectableSelected && !allRowsIrredeemable)}
                       onChange={handleSelectAllRows}
                       color="secondary"
                     />

--- a/src/components/user/AddWallet.tsx
+++ b/src/components/user/AddWallet.tsx
@@ -1,12 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
 import {
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   useTheme,
-  useMediaQuery,
   Typography,
   Box,
   Collapse,
@@ -14,24 +9,17 @@ import {
   IconButton
 } from "@mui/material";
 import { useWallet } from '@meshsdk/react';
-import Link from "@components/Link";
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WalletList from "./WalletList";
 import { useAlert } from "@contexts/AlertContext";
 import { walletsList } from "@lib/walletsList";
-import { deleteEmptyUser } from "@server/utils/deleteEmptyUser";
-import { signIn } from "next-auth/react";
 import { trpc } from "@lib/utils/trpc";
 import { getShorterAddress } from "@lib/utils/general";
 import ClearIcon from '@mui/icons-material/Clear';
 import { useWalletContext } from '@contexts/WalletContext';
 import { TRPCClientError } from "@trpc/client";
 
-interface IAddWallet {
-
-}
-
-export const AddWallet: FC<IAddWallet> = () => {
+export const AddWallet: FC = () => {
   const theme = useTheme();
   const { addAlert } = useAlert()
   const { connect, wallet, connected, name } = useWallet()

--- a/src/components/user/WalletList.tsx
+++ b/src/components/user/WalletList.tsx
@@ -20,7 +20,7 @@ interface IWalletList {
 export const WalletList: FC<IWalletList> = ({ setOpen, setLoading }) => {
   const theme = useTheme();
   const wallets = useWalletList();
-  const { wallet, connected, name, connecting, connect, disconnect, error } = useWallet()
+  const { connecting, connect } = useWallet()
   const [openAddWallet, setOpenAddWallet] = useState(false)
 
   const handleClose = () => {
@@ -31,8 +31,6 @@ export const WalletList: FC<IWalletList> = ({ setOpen, setLoading }) => {
     try {
       setLoading(true)
       await connect(walletName)
-    } catch {
-
     } finally {
       handleClose()
       setLoading(false)
@@ -67,7 +65,7 @@ export const WalletList: FC<IWalletList> = ({ setOpen, setLoading }) => {
                 Install a wallet:
               </Typography>
 
-              {notInstalledWallets.map((walletListEntry, i) => (
+              {notInstalledWallets.map((walletListEntry) => (
                 <WalletListItemComponent {...walletListEntry} link key={walletListEntry.name} handleConnect={handleConnect} />
               ))}
             </Collapse>

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -20,7 +20,7 @@ export const AlertProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const addAlert = (type: Alert['type'], message: Alert['message']) => {
     const id = Date.now().toString(); // Using timestamp as unique ID for simplicity
     setAlerts((prevAlerts) => [...prevAlerts, { id, type, message }]);
-    setTimeout(() => removeAlert(id), 4000);
+    setTimeout(() => removeAlert(id), 6000);
   };
 
   const removeAlert = (id: string) => {

--- a/src/lib/utils/cardano.ts
+++ b/src/lib/utils/cardano.ts
@@ -9,10 +9,7 @@ export const useCardano = () => {
             try {
                 const api = await BrowserWallet.enable(walletName);
                 const changeAddress = await api.getChangeAddress();
-                if (walletAddress === changeAddress) {
-                    return true;
-                }
-                return false;
+                return walletAddress === changeAddress;
             } catch {
                 return false;
             }

--- a/src/lib/walletsList.ts
+++ b/src/lib/walletsList.ts
@@ -1,107 +1,108 @@
 import { Wallet } from "@meshsdk/core";
 
-export const VESPR_ICON = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbDpzcGFjZT0icHJlc2VydmUiIHZpZXdCb3g9IjAgMCA2NDAgNjQwIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJyZ2JhKDksIDE0LCAyMiwgMSkiIHJ4PSIxMDAiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtNDU1LjUxOCAxNzguMDQwOC0xMzUuMjQzNiAxODIuNzV2LS43Mzk2TDE4NC45NjIgMTc3LjE4MDhINzAuOTI2bDM1LjE3NCA0Ny41NThoMzMuOTE4NEwzMjAuMjA1NiA0NjIuMTE2di45NjMybDE4MC4yNTYtMjM3LjQ5NzZINTM0LjM4bDM1LjE3NC00Ny41NDA4SDQ1NS41MTh6Ii8+PHBhdGggZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS1taXRlcmxpbWl0PSIxMCIgZD0iTTMwMC45OTkgMTAyaC4wMDIiLz48L3N2Zz4='
+export const VESPR_ICON =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbDpzcGFjZT0icHJlc2VydmUiIHZpZXdCb3g9IjAgMCA2NDAgNjQwIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJyZ2JhKDksIDE0LCAyMiwgMSkiIHJ4PSIxMDAiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtNDU1LjUxOCAxNzguMDQwOC0xMzUuMjQzNiAxODIuNzV2LS43Mzk2TDE4NC45NjIgMTc3LjE4MDhINzAuOTI2bDM1LjE3NCA0Ny41NThoMzMuOTE4NEwzMjAuMjA1NiA0NjIuMTE2di45NjMybDE4MC4yNTYtMjM3LjQ5NzZINTM0LjM4bDM1LjE3NC00Ny41NDA4SDQ1NS41MTh6Ii8+PHBhdGggZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS1taXRlcmxpbWl0PSIxMCIgZD0iTTMwMC45OTkgMTAyaC4wMDIiLz48L3N2Zz4=";
 
 export const walletNameToId = (name: string) => {
   return {
-    Nami: 'nami',
-    'Begin Wallet': 'begin',
-    eternl: 'eternl',
-    'Flint Wallet': 'flint',
-    lace: 'lace',
-    NuFi: 'nufi',
-    GeroWallet: 'gero',
-    'Typhon Wallet': 'typhon',
-    VESPR: 'vespr'
+    Nami: "nami",
+    "Begin Wallet": "begin",
+    eternl: "eternl",
+    "Flint Wallet": "flint",
+    lace: "lace",
+    NuFi: "nufi",
+    GeroWallet: "gero",
+    "Typhon Wallet": "typhon",
+    VESPR: "vespr",
   }[name];
 };
 
 export const walletDataByName = (name: string) => {
-  return walletsList.find(wallet => wallet.connectName === name);
-}
+  return walletsList.find((wallet) => wallet.connectName === name);
+};
 
 export const walletsList: TWalletListItem[] = [
   {
-    name: 'Begin',
-    connectName: 'Begin Wallet',
-    icon: '/wallets/begin-light.svg',
-    iconDark: '/wallets/begin-dark.svg',
+    name: "Begin",
+    connectName: "Begin Wallet",
+    icon: "/wallets/begin-light.svg",
+    iconDark: "/wallets/begin-dark.svg",
     mobile: true,
-    url: 'https://begin.is/'
+    url: "https://begin.is/",
   },
   {
-    name: 'Eternl',
-    connectName: 'eternl',
-    icon: '/wallets/eternl-light.svg',
-    iconDark: '/wallets/eternl-light.svg',
+    name: "Eternl",
+    connectName: "eternl",
+    icon: "/wallets/eternl-light.svg",
+    iconDark: "/wallets/eternl-light.svg",
     mobile: true,
-    url: 'https://eternl.io/'
+    url: "https://eternl.io/",
   },
   {
-    name: 'Flint',
-    connectName: 'Flint Wallet',
-    icon: '/wallets/flint-light.svg',
-    iconDark: '/wallets/flint-light.svg',
+    name: "Flint",
+    connectName: "Flint Wallet",
+    icon: "/wallets/flint-light.svg",
+    iconDark: "/wallets/flint-light.svg",
     mobile: true,
-    url: 'https://flint-wallet.com/'
+    url: "https://flint-wallet.com/",
   },
   {
-    name: 'Lace',
-    connectName: 'lace',
-    icon: '/wallets/lace.svg',
-    iconDark: '/wallets/lace.svg',
+    name: "Lace",
+    connectName: "lace",
+    icon: "/wallets/lace.svg",
+    iconDark: "/wallets/lace.svg",
     mobile: false,
-    url: 'https://www.lace.io/'
+    url: "https://www.lace.io/",
   },
   {
-    name: 'Nami',
-    connectName: 'Nami',
-    icon: '/wallets/nami-light.svg',
-    iconDark: '/wallets/nami-light.svg',
+    name: "Nami",
+    connectName: "Nami",
+    icon: "/wallets/nami-light.svg",
+    iconDark: "/wallets/nami-light.svg",
     mobile: false,
-    url: 'https://namiwallet.io/'
+    url: "https://namiwallet.io/",
   },
   {
-    name: 'NuFi',
-    connectName: 'NuFi',
-    icon: '/wallets/nufi-navbar-light.svg',
-    iconDark: '/wallets/nufi-navbar-dark.svg',
+    name: "NuFi",
+    connectName: "NuFi",
+    icon: "/wallets/nufi-navbar-light.svg",
+    iconDark: "/wallets/nufi-navbar-dark.svg",
     mobile: false,
-    url: 'https://nu.fi/'
+    url: "https://nu.fi/",
   },
   {
-    name: 'Gero',
-    connectName: 'GeroWallet',
-    icon: '/wallets/gerowallet.svg',
-    iconDark: '/wallets/gerowallet.svg',
+    name: "Gero",
+    connectName: "GeroWallet",
+    icon: "/wallets/gerowallet.svg",
+    iconDark: "/wallets/gerowallet.svg",
     mobile: true,
-    url: 'https://gerowallet.io/'
+    url: "https://gerowallet.io/",
   },
   {
-    name: 'Typhon',
-    connectName: 'Typhon Wallet',
-    icon: '/wallets/typhon-light.svg',
-    iconDark: '/wallets/typhon-dark.svg',
+    name: "Typhon",
+    connectName: "Typhon Wallet",
+    icon: "/wallets/typhon-light.svg",
+    iconDark: "/wallets/typhon-dark.svg",
     mobile: false,
-    url: 'https://typhonwallet.io/'
+    url: "https://typhonwallet.io/",
   },
   {
-    name: 'VESPR',
-    connectName: 'VESPR',
-    icon: '/wallets/vespr-light.svg',
-    iconDark: '/wallets/vespr-dark.svg',
+    name: "VESPR",
+    connectName: "VESPR",
+    icon: "/wallets/vespr-light.svg",
+    iconDark: "/wallets/vespr-dark.svg",
     mobile: true,
-    url: 'https://www.vespr.xyz/'
-  }
-]
+    url: "https://www.vespr.xyz/",
+  },
+];
 
 export const filterInstalledWallets = (wallets: Wallet[]) => {
-  return walletsList.filter(walletListEntry => {
-    const correspondingWallet = wallets.find(wallet =>
+  return walletsList.filter((walletListEntry) => {
+    const correspondingWallet = wallets.find((wallet) =>
       walletListEntry.connectName === wallet.name &&
-      !(wallet.icon === VESPR_ICON && wallet.name !== 'VESPR')
+      !(wallet.icon === VESPR_ICON && wallet.name !== "VESPR")
     );
 
     return correspondingWallet !== undefined;
   });
-}
+};

--- a/src/server/services/syncApi.ts
+++ b/src/server/services/syncApi.ts
@@ -1,20 +1,20 @@
-import axios from "axios";
 import { mapAxiosErrorToTRPCError } from "@server/utils/mapErrors";
 import { TRPCError } from "@trpc/server";
+import axios from "axios";
 
 export type StakeSummary = {
   poolStats: {
     [key: string]: StakeStats;
-  }
+  };
   totalStats: StakeStats;
-}
+};
 
 export type StakeStats = {
   totalPortfolio: string;
   totalVested: string;
   totalStaked: string;
   unclaimedTokens: string;
-}
+};
 
 export type StakePosition = {
   name: string;
@@ -25,12 +25,13 @@ export type StakePosition = {
   interest: number;
   txHash: string;
   txIndex: string;
-}
+  stakeKey: string;
+};
 
 export type StakePoolResponse = {
   amount: CardanoValue;
   stakePool: StakePoolDatum;
-}
+};
 
 export type CardanoValue = {
   coin: string;
@@ -38,27 +39,27 @@ export type CardanoValue = {
     [policyId: string]: {
       [assetName: string]: string;
     };
-  }
+  };
 };
 
 export type StakePoolDatum = {
   owner: CardanoCredential;
   rewardSettings: RewardSettings[];
-}
+};
 
 export type CardanoCredential = {
   keyHash: string;
-}
+};
 
 export type RewardSettings = {
   lockDuration: BigInt;
   rewardMultiplier: Rational;
-}
+};
 
 export type Rational = {
   numerator: BigInt;
   denominator: BigInt;
-}
+};
 
 export type AddStakeRequest = {
   stakePool: StakePoolIdentifier;
@@ -67,27 +68,27 @@ export type AddStakeRequest = {
   rewardSettingIndex: number;
   walletUtxoListCbor: string[];
   amount: string;
-}
+};
 
 export type FinalizeTxRequest = {
   unsignedTxCbor: string;
   txWitnessCbor: string;
-}
+};
 
 export type StakePoolIdentifier = {
   address: string;
   ownerPkh: string;
   policyId: string;
   assetName: string;
-}
+};
 
 export type StakeRequestsResponse = {
   total: number;
   data: StakeRequest[];
   extra: {
-    slotData: { [slot: string]: number }
-  }
-}
+    slotData: { [slot: string]: number };
+  };
+};
 
 export type StakeRequest = {
   slot: string;
@@ -98,143 +99,172 @@ export type StakeRequest = {
   stakePoolProxy: {
     lockTime: string;
   };
-}
+};
 
 export type OutputReference = {
   txHash: string;
   index: string;
-}
+};
 
 export type CancelStakeRequest = {
   stakeRequestOutputReference: OutputReference;
   walletUtxoListCbor: string[];
-}
+};
 
 export type ClaimStakeRequest = {
   stakeUtxoOutputReferences: OutputReference[];
   walletUtxoListCbor: string[];
   changeAddress: string;
-}
+};
 
 export const coinectaSyncApi = {
   async getStakeSummary(stakeKeys: string[]): Promise<StakeSummary> {
     try {
-      const response = await syncApi.post('/stake/summary', stakeKeys)
+      const response = await syncApi.post("/stake/summary", stakeKeys);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
   async getStakePositions(stakeKeys: string[]): Promise<StakePosition[]> {
     try {
-      const response = await syncApi.post('/stake/positions', stakeKeys)
+      const response = await syncApi.post("/stake/positions", stakeKeys);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
-  async getStakePool(address: string, ownerPkh: string, policyId: string, assetName: string): Promise<StakePoolResponse> {
+  async getStakePool(
+    address: string,
+    ownerPkh: string,
+    policyId: string,
+    assetName: string,
+  ): Promise<StakePoolResponse> {
     try {
-      const response = await syncApi.get(`/stake/pool/${address}/${ownerPkh}/${policyId}/${assetName}`)
+      const response = await syncApi.get(
+        `/stake/pool/${address}/${ownerPkh}/${policyId}/${assetName}`,
+      );
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
-  async getStakeRequests(walletAddresses: string[], page: number = 1, limit: number = 5): Promise<StakeRequestsResponse> {
+  async getStakeRequests(
+    walletAddresses: string[],
+    page: number = 1,
+    limit: number = 5,
+  ): Promise<StakeRequestsResponse> {
     try {
-      const response = await syncApi.post(`/stake/requests?page=${page}&limit=${limit}`, walletAddresses)
+      const response = await syncApi.post(
+        `/stake/requests?page=${page}&limit=${limit}`,
+        walletAddresses,
+      );
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
   async addStakeTx(request: AddStakeRequest): Promise<string> {
     try {
-      const response = await syncApi.post('/transaction/stake/add', request)
+      const response = await syncApi.post("/transaction/stake/add", request);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
   async claimStakeTx(request: ClaimStakeRequest): Promise<string> {
     try {
-      const response = await syncApi.post('/transaction/stake/claim', request)
+      const response = await syncApi.post("/transaction/stake/claim", request);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
   async cancelStakeTx(request: CancelStakeRequest): Promise<string> {
     try {
-      const response = await syncApi.post('/transaction/stake/cancel', request)
+      const response = await syncApi.post("/transaction/stake/cancel", request);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
   },
   async finalizeTx(request: FinalizeTxRequest): Promise<string> {
     try {
-      const response = await syncApi.post('/transaction/finalize', request)
+      const response = await syncApi.post("/transaction/finalize", request);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         throw mapAxiosErrorToTRPCError(error);
-      }
-      else {
-        console.error(error)
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'An unknown error occurred' });
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
       }
     }
-  }
+  },
 };
-
 
 export const syncApi = axios.create({
   baseURL: process.env.COINECTA_SYNC_API,
   headers: {
-    'Content-type': 'application/json;charset=utf-8',
-  }
+    "Content-type": "application/json;charset=utf-8",
+  },
 });

--- a/src/server/services/syncApi.ts
+++ b/src/server/services/syncApi.ts
@@ -118,8 +118,9 @@ export type ClaimStakeRequest = {
 };
 
 export const coinectaSyncApi = {
-  async getStakeSummary(stakeKeys: string[]): Promise<StakeSummary> {
+  async getStakeSummary(stakeKeys: string[]): Promise<StakeSummary | null> {
     try {
+      if (stakeKeys.length === 0) return null;
       const response = await syncApi.post("/stake/summary", stakeKeys);
       return response.data;
     } catch (error) {
@@ -136,6 +137,7 @@ export const coinectaSyncApi = {
   },
   async getStakePositions(stakeKeys: string[]): Promise<StakePosition[]> {
     try {
+      if (stakeKeys.length === 0) return [];
       const response = await syncApi.post("/stake/positions", stakeKeys);
       return response.data;
     } catch (error) {


### PR DESCRIPTION
Overview

This PR adds new features and fixes issues listed below:

Redeem Rewards Across Multiple Wallet Vendors
- Users now have the capability to redeem rewards through various wallet vendors. Note that users can only redeem rewards under one wallet vendor at a time

Improved Notification System
- Descriptive notifications have been added to provide clear guidance to users on navigating the application, enhancing the overall user experience.

![image](https://github.com/coinecta/coinecta-frontend/assets/585569/153395e0-e945-4048-9be9-02d18b347fc4)

![image](https://github.com/coinecta/coinecta-frontend/assets/585569/8c7791f4-dd53-44e9-9b3a-e02c023f5316)

Extended Alert Notification Pop-up Duration
- The visibility duration of alert notification pop-ups has been extended, ensuring users have ample time to read and respond to important alerts.

Added "Redeem From" Dropdown
- The "Redeem From" dropdown excludes connected wallets with no positions. Additionally, when all positions displayed in the table belong to a single wallet, the "Redeem From" dropdown is automatically hidden, improving interface clarity.
- Selecting a wallet type from this dropdown will automatically sort the table items, placing the positions with the selected wallet at the top of the table.

![image](https://github.com/coinecta/coinecta-frontend/assets/585569/110fd7d3-794a-43bd-a6ad-0f39531caadd)


Fixed loading issues in the stake positions table
- Previously, the table displays dummy data while fetching the actual data, providing no visual indication of the ongoing fetch process. Now, the table displays visual cues indicating that data is being fetched.

Fixed bug with "Select All" Checkbox:
- Previously, when all items in the table were irredeemable, the "Select all" checkbox would automatically be checked. This issue has been resolved.

This PR closes issues #64 and #71

Co-authored-by: @Mercurial <clark_alesna@hotmail.com>
Co-authored-by: @phonz-dev <phonz.dev@gmail.com>
Co-authored-by: @rjlacanlaled <rjlacanlaled@gmail.com>

