### PR TITLE
fix: Improve readability of connected wallet addresses in light mode

### DIFF
--- a/src/components/user/ConnectedWalletItem.tsx
+++ b/src/components/user/ConnectedWalletItem.tsx
@@ -47,7 +47,7 @@ export const ConnectedWalletItem: FC<ConnectedWalletItemProps> = ({ wallet, key,
                         variant="square"
                     />
                 </Box>
-                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', color: theme.palette.text.primary }}>
                     {getShorterAddress(wallet.address, 12)}
                 </Box>
             </Box>


### PR DESCRIPTION
This pull request addresses an issue where the text color of the connected wallet addresses within the ChooseWallet component was unreadable in light mode.

Before:
![Screenshot 2024-04-04 at 3 52 26 PM](https://github.com/coinecta/coinecta-frontend/assets/81457844/a2aaf2de-3158-466d-976c-d8130150ff5e)

After:
![Screenshot 2024-04-04 at 3 50 31 PM](https://github.com/coinecta/coinecta-frontend/assets/81457844/e7586a61-2484-4706-9465-d914828ae710)

This PR closes issue #75 