### PR TITLE
fix: Eternl wallet infinite connection loop

### DIFF
--- a/src/components/WalletSelectDropdown.tsx
+++ b/src/components/WalletSelectDropdown.tsx
@@ -25,7 +25,6 @@ const WalletSelectDropdown = () => {
   const { isWalletConnected: _isWalletConnected, setSelectedAddresses: _setSelectedAddresses, getSelectedAddresses: _getSelectedAddresses } = useCardano()
   const [walletAddresses, setWalletAddresses] = useState<string[]>([])
   const [selectedAddresses, setSelectedAddress] = useState<string[]>([])
-  const [time, setTime] = useState<number>(0);
   const [isConnectedByWallets, setIsConnectedByWallets] = useState<Record<string, boolean>>({})
 
   const isWalletConnected = useCallback(_isWalletConnected, [_isWalletConnected]);
@@ -35,14 +34,6 @@ const WalletSelectDropdown = () => {
   const getWallets = trpc.user.getWallets.useQuery()
 
   const wallets = useMemo(() => getWallets.data && getWallets.data.wallets, [getWallets]);
-
-  // Refresh component every 10 seconds to update the styles indicating the connection status of displayed wallets
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setTime(time => time + 1);
-    }, 10000);
-    return () => clearInterval(interval);
-  }, []);
 
   useEffect(() => {
     if (wallets && walletAddresses.length < 1) {
@@ -86,7 +77,7 @@ const WalletSelectDropdown = () => {
       }
     };
     execute();
-  }, [wallets, time]);
+  }, [wallets]);
 
   return (
     <FormControl fullWidth>

--- a/src/components/dashboard/staking/StakePositionTable.tsx
+++ b/src/components/dashboard/staking/StakePositionTable.tsx
@@ -95,14 +95,14 @@ const StakePositionTable = <T extends Record<string, any>>({
 
   useEffect(() => {
     if (currentWallet) setSelectedRows!(new Set());
-  }, [currentWallet, setSelectedRows, selectedAddresses])
+  }, [currentWallet, selectedAddresses])
 
   useEffect(() => {
     if (selectedRows!.size >= 1 && !isInfoSnackbarShown){
       addAlert('info', 'Please note: You can only redeem rewards using one wallet type at a time.');
       setIsInfoSnackbarShown(true);
     }
-  }, [selectedRows, isInfoSnackbarShown, addAlert])
+  }, [selectedRows, isInfoSnackbarShown])
   
   useEffect(() => {
     data.sort((a, b) => {
@@ -132,7 +132,7 @@ const StakePositionTable = <T extends Record<string, any>>({
     if (isAllRowsStakedUnderSingleWallet) {
       setCurrentWallet(Object.values(stakeKeyWalletMapping)[0]);
     }
-  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet, setCurrentWallet]);
+  }, [stakeKeyWalletMapping, isAllRowsStakedUnderSingleWallet]);
 
 
   const isTableWiderThanParent = parentWidth < paperWidth


### PR DESCRIPTION
# Overview
This PR fixes an issue where the Eternl wallet was repeatedly enabled, resulting in the continuous display of its dialog.

![image](https://github.com/coinecta/coinecta-frontend/assets/81457844/84d96c50-c07a-4d98-91f8-84da8ef21aa1)

## Cause of issue
- Removing the coinecta website from Eternl's list of permitted sites results in an infinite loop of this dialog being displayed.
- Since the 'isWalletConnected' as a useEffect dependency causes an infinite re-render, the code that enables the Eternl wallet was being called incessantly.

## Changes made
- Removed the 'isWalletConnected' function as a useEffect dependency. This resolves the infinite loop issue, reducing its occurrence to every 10 seconds due to the code that refreshes the data every 10 seconds.
- Issue #81 was also resolved when 'isWalletConnected' was removed as a dependency.

This PR closes issues #76 and #81