### PR TITLE
fix: Dashboard overview data shows 'zero' while data is being retrieved

### DIFF
--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -46,9 +46,9 @@ const Dashboard: FC = () => {
   }, [queryStakeSummary.data]);
 
   useEffect(() => {
-    setIsLoading(!queryStakeSummary.isSuccess && !isStakingKeysLoaded);
+    setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded);
   }, [isStakingKeysLoaded, queryStakeSummary.isSuccess]);
-
+  
   const formatNumber = (num: number, key: string) => `${num.toLocaleString(undefined, {
     maximumFractionDigits: 2
   })}${key !== '' && key != null ? ` ${key}` : ''}`;


### PR DESCRIPTION
## Issue
When data is being retrieved for the dashboard overview page, it displays 'zero' placeholders instead of utilizing the skeleton component.

## Solution
I have updated the logic for setting the 'isLoading' state to ensure that it remains 'true' while either of the 'queryStakeSummary' or the staking keys data is still being retrieved. This change now ensures that the frontend utilizes the skeleton component while either of these data is being retrieved.

This PR closes issue #83