### PR TITLE
fix: Positions to be redeemed not displaying on RedeemConfirm dialog

### DIFF
--- a/src/components/dashboard/staking/RedeemConfirm.tsx
+++ b/src/components/dashboard/staking/RedeemConfirm.tsx
@@ -37,11 +37,10 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
   redeemWallet,
   claimStakeRequest,
 }) => {
-  const { cnctDecimals } = useToken();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
-  const { connected, wallet } = useWallet();
+  const { connected } = useWallet();
   const { sessionData, sessionStatus } = useWalletContext();
   const [cardanoApi, setCardanoApi] = useState<any>(undefined);
   const [isSigning, setIsSigning] = useState(false);
@@ -131,7 +130,7 @@ const RedeemConfirm: FC<IRedeemConfirmProps> = ({
           <DataSpread
             key={`${item.currency}-${i}`}
             title={item.currency}
-            data={`${formatTokenWithDecimals(BigInt(item.amount), cnctDecimals)}`}
+            data={item.amount}
           />
         ))}
       </DialogContent>


### PR DESCRIPTION
## Issue
The summary of positions to be redeemed does not show on the RedeemConfirm dialog

![image](https://github.com/coinecta/coinecta-frontend/assets/81457844/36dc2835-5c9f-4246-875c-a2c380555c47)

## Cause
With the introduction of the multi-redeem feature, it became necessary to sort the data. The previous implementation that displays the summary of the positions to be redeemed relied on unsorted data, causing a breaking change.

## Solution
This PR reimplements the display of the positions to be redeemed but now references the sorted data.

After reimplementation:
![image](https://github.com/coinecta/coinecta-frontend/assets/81457844/3a7cc3f8-3198-4943-8667-7130879d51c1)

This PR closes issue #85 