### PR TITLE
fix: revert to wallet apis for fetching utxos and balance

### DIFF
--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useToken } from '@components/hooks/useToken';
 import { useWalletContext } from '@contexts/WalletContext';
 import { formatTokenWithDecimals } from '@lib/utils/assets';
 import { trpc } from '@lib/utils/trpc';
+import { BrowserWallet } from '@meshsdk/core';
 import { useWallet } from '@meshsdk/react';
 import {
   Box,
@@ -68,10 +69,10 @@ const Dashboard: FC = () => {
         const stakeKeysPromises = userWallets.map(async userWallet => {
           if (selectedAddresses.indexOf(userWallet.changeAddress) === -1) return [];
           try {
-            const usedAddressesRawUtxos = await getRawUtxosMultiAddress.mutateAsync([userWallet.changeAddress]);
-            const balance = await getBalanceFromRawUtxos.mutateAsync(usedAddressesRawUtxos);
-            const stakeKeys = balance.assets.map((asset) => asset.policyId + asset.name).filter((unit) => unit.includes(STAKING_KEY_POLICY!));
-            const processedStakeKeys = stakeKeys.map((key) => key.replace('000de140', ''));
+            const browserWallet = await BrowserWallet.enable(userWallet.type);
+            const balance = await browserWallet.getBalance();
+            const stakeKeys = balance.filter((asset) => asset.unit.includes(STAKING_KEY_POLICY));
+            const processedStakeKeys = stakeKeys.map((key) => key.unit.replace('000de140', ''));
             return processedStakeKeys;
           } catch {
             return []

--- a/src/components/dashboard/pages/StakePositionsPage.tsx
+++ b/src/components/dashboard/pages/StakePositionsPage.tsx
@@ -47,27 +47,20 @@ const StakePositions: FC = () => {
   const [changeAddress, setChangeAddress] = useState<string | undefined>(undefined);
   const { selectedAddresses } = useWalletContext();
   const { isWalletConnected: _isWalletConnected } = useCardano();
-  const utils = trpc.useUtils();
+  const [walletUtxosCbor, setWalletUtxosCbor] = useState<string[]>([]);
 
+  const utils = trpc.useUtils();
   const isWalletConnected = useCallback(_isWalletConnected, [_isWalletConnected]);
 
   const getWallets = trpc.user.getWallets.useQuery()
   const userWallets = useMemo(() => getWallets.data && getWallets.data.wallets, [getWallets]);
 
   const [currentWallet, setCurrentWallet] = useState<string | undefined>(undefined);
-  const [currentWalletAddress, setCurrentWalletAddress] = useState<string | undefined>(undefined);
-
   const queryStakeSummary = trpc.sync.getStakeSummary.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const summary = useMemo((() => queryStakeSummary.data), [queryStakeSummary.data]);
   
   const queryStakePositions = trpc.sync.getStakePositions.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
   const positions = useMemo(() => queryStakePositions.data ?? [], [queryStakePositions.data]);
-
-  const queryCurrentWalletRawUtxos = trpc.sync.getRawUtxos.useQuery(currentWalletAddress ?? '', { retry: 0, refetchInterval: 5000 });
-  const walletUtxosCbor = useMemo(() => queryCurrentWalletRawUtxos.data, [queryCurrentWalletRawUtxos.data]);
-
-  const getRawUtxosMultiAddress = trpc.sync.getRawUtxosMultiAddress.useMutation();
-  const getBalanceFromRawUtxos = trpc.sync.getBalanceFromRawUtxos.useMutation();
 
   const STAKE_POOL_SUBJECT = process.env.STAKE_POOL_ASSET_POLICY! + process.env.STAKE_POOL_ASSET_NAME!;
 
@@ -153,14 +146,20 @@ const StakePositions: FC = () => {
     const execute = async () => {
       if (connected && sessionStatus === 'authenticated' && currentWallet) {
         try {
-           if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
+            if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
           
-           const browserWallet = await BrowserWallet.enable(currentWallet);
-           const changeAddress = await browserWallet.getChangeAddress();
-           setChangeAddress(changeAddress);
+            // Update Utxos
+            setWalletUtxosCbor([]);
+            if (window.cardano[walletNameToId(currentWallet!)!] === undefined) return;
+            const api = await window.cardano[walletNameToId(currentWallet!)!].enable();
+            const utxos = await api.getUtxos();
+            const collateral = api.experimental.getCollateral === undefined ? [] : await api.experimental.getCollateral();
+            setWalletUtxosCbor([...utxos!, ...(collateral ?? [])]);
 
-          setCurrentWalletAddress(changeAddress);
-           
+            // Update change address
+            const browserWallet = await BrowserWallet.enable(currentWallet);
+            const changeAddress = await browserWallet.getChangeAddress();
+            setChangeAddress(changeAddress);
         } catch (ex) {
           console.error("Error getting utxos", ex);
         }
@@ -186,12 +185,12 @@ const StakePositions: FC = () => {
           try {
             if (!(await isWalletConnected(userWallet.type, userWallet.changeAddress))) return [];
             if (selectedAddresses.indexOf(userWallet.changeAddress) === -1) return [];
-            const usedAddressesRawUtxos = await getRawUtxosMultiAddress.mutateAsync([userWallet.changeAddress]);
-            const balance = await getBalanceFromRawUtxos.mutateAsync(usedAddressesRawUtxos);
-            const stakeKeys = balance.assets.map((asset) => asset.policyId + asset.name).filter((unit) => unit.includes(STAKING_KEY_POLICY!));
-            const processedStakeKeys = stakeKeys.map((key) => key.replace('000de140', ''));
+            const browserWallet = await BrowserWallet.enable(userWallet.type);
+            const balance = await browserWallet.getBalance();
+            const stakeKeys = balance.filter((asset) => asset.unit.includes(STAKING_KEY_POLICY));
+            const processedStakeKeys = stakeKeys.map((key) => key.unit.replace('000de140', ''));
             stakeKeys.forEach((key) => {
-              stakeKeyWallet[key.replace('000de140', '')] = userWallet.type;
+              stakeKeyWallet[key.unit.replace('000de140', '')] = userWallet.type;
             });
             return processedStakeKeys;
           } catch {

--- a/src/components/dashboard/staking/StakeConfirm.tsx
+++ b/src/components/dashboard/staking/StakeConfirm.tsx
@@ -67,7 +67,6 @@ const StakeConfirm: FC<IStakeConfirmProps> = ({
   const utils = trpc.useUtils();
   const addStakeTxMutation = trpc.sync.addStakeTx.useMutation();
   const finaliseTxMutation = trpc.sync.finalizeTx.useMutation();
-  const getRawUtxosMultiAddress = trpc.sync.getRawUtxosMultiAddress.useMutation();
   
   const handleClose = () => setOpen(false);
 
@@ -105,13 +104,7 @@ const StakeConfirm: FC<IStakeConfirmProps> = ({
   const processTxWithApi = async (walletName: string, api: any) => {
     const browserWallet = await BrowserWallet.enable(walletName);
     const changeAddress = await browserWallet.getChangeAddress();
-
-    let apiUTxos = await getRawUtxosMultiAddress.mutateAsync([changeAddress]);
-    const collateralUtxos = await api.experimental.getCollateral();
-
-    if (collateralUtxos !== undefined) {
-      apiUTxos = apiUTxos.filter((utxo: any) => !collateralUtxos.includes(utxo));
-    }
+    const apiUTxos = await api.getUtxos();
 
     const addStakeRequest: AddStakeRequest = {
       stakePool: {


### PR DESCRIPTION
To fix timeout issues introduced by #79, this PR reverts to using wallet api instead of the new backend endpoints. 