### PR TITLE
feat: integrate stake stats api to dashboard

### DIFF
--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,15 +1,15 @@
 import React, { FC, ReactNode } from 'react';
 import { Box, Paper, SxProps, Theme } from '@mui/material';
 import { useWalletContext } from '@contexts/WalletContext';
-import { minHeight } from '@mui/system';
 
 interface DashboardCardProps {
   children?: ReactNode;
   sx?: SxProps<Theme>;
   center?: true;
+  standard?: boolean;
 }
 
-const DashboardCard: FC<DashboardCardProps> = ({ children, sx, center }) => {
+const DashboardCard: FC<DashboardCardProps> = ({ children, sx, center, standard }) => {
   const { sessionStatus } = useWalletContext();
 
   const baseStyles: SxProps<Theme> = {
@@ -39,11 +39,13 @@ const DashboardCard: FC<DashboardCardProps> = ({ children, sx, center }) => {
 
   return (
     <Paper variant="outlined" sx={finalStyles}>
-      {sessionStatus === 'loading'
+      {standard ?
+        children :
+        (sessionStatus === 'loading'
         ? 'Loading...'
         : sessionStatus === 'unauthenticated'
           ? 'Sign in to see positions'
-          : children}
+          : children)}
     </Paper>
   );
 };

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -4,9 +4,10 @@ import WalletSelectDropdown from '@components/WalletSelectDropdown';
 
 interface IDashboardHeaderProps {
   title: string;
+  isDropdownHidden?: boolean;
 }
 
-const DashboardHeader: FC<IDashboardHeaderProps> = ({ title }) => {
+const DashboardHeader: FC<IDashboardHeaderProps> = ({ title, isDropdownHidden = false }) => {
   const theme = useTheme()
   return (
     <>
@@ -21,7 +22,7 @@ const DashboardHeader: FC<IDashboardHeaderProps> = ({ title }) => {
         <Typography variant="h5">
           {title}
         </Typography>
-        <Box sx={{ minWidth: '250px' }}>
+        <Box sx={{ minWidth: '250px', display: isDropdownHidden ? 'none' : 'block' }}>
           <WalletSelectDropdown />
         </Box>
       </Box>

--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -106,7 +106,7 @@ const AddStakePage: FC = () => {
   return (
     <>
       <Box sx={{ mb: 4 }}>
-        <DashboardHeader title="Add stake" />
+        <DashboardHeader title="Add Stake" />
         <Grid container spacing={2}>
           <Grid xs={12} md={7}>
             <DashboardCard center>

--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -8,13 +8,15 @@ import {
   Box,
   Button,
   Skeleton,
-  Typography
+  Typography,
+  useTheme
 } from '@mui/material';
 import Grid from '@mui/system/Unstable_Grid/Grid';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import DashboardHeader from '../DashboardHeader';
 import StakeConfirm from '../staking/StakeConfirm';
 import StakeDuration from '../staking/StakeDuration';
+import { pink, orange, purple } from '@mui/material/colors';
 
 const options = [
   {
@@ -53,6 +55,8 @@ const AddStakePage: FC = () => {
   const [durations, setDurations] = useState<number[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [openConfirmationDialog, setOpenConfirmationDialog] = useState(false);
+
+  const theme = useTheme();
 
   const getStakePoolQuery = trpc.sync.getStakePool.useQuery({
     address: STAKE_POOL_VALIDATOR_ADDRESS,
@@ -99,118 +103,188 @@ const AddStakePage: FC = () => {
   const rewards = (Number(cnctAmount) ? Number(cnctAmount) * (options.find(option => option.duration === stakeDuration)?.interest || 0) : 0)
 
   return (
-    <Box sx={{ mb: 4 }}>
-      <DashboardHeader title="Add stake" />
-      <Grid container spacing={2}>
-        <Grid xs={12} md={7}>
-          <DashboardCard center>
-            <Typography variant="h3" sx={{ mb: 2 }}>
-              Stake Coinecta
-            </Typography>
-            <Box sx={{ width: '100%', mb: 3 }}>
-              {isLoading ?
-                <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={200} /></div> :
-                <StakeDuration
-                  duration={stakeDuration}
-                  setDuration={setStakeDuration}
-                  durations={durations}
+    <>
+      <Box sx={{ mb: 4 }}>
+        <DashboardHeader title="Add stake" />
+        <Grid container spacing={2}>
+          <Grid xs={12} md={7}>
+            <DashboardCard center>
+              <Typography variant="h3" sx={{ mb: 2 }}>
+                Stake Coinecta
+              </Typography>
+              <Box sx={{ width: '100%', mb: 3 }}>
+                {isLoading ?
+                  <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={200} /></div> :
+                  <StakeDuration
+                    duration={stakeDuration}
+                    setDuration={setStakeDuration}
+                    durations={durations}
+                  />
+                }
+              </Box>
+              <Box sx={{ width: '100%', mb: 3 }}>
+                <StakeInput
+                  inputValue={cnctAmount}
+                  setInputValue={setCnctAmount}
+                  onKeyDown={handleKeyDown}
                 />
-              }
-            </Box>
-            <Box sx={{ width: '100%', mb: 3 }}>
-              <StakeInput
-                inputValue={cnctAmount}
-                setInputValue={setCnctAmount}
-                onKeyDown={handleKeyDown}
-              />
-            </Box>
-            <Box>
-              <Button
-                variant="contained"
-                color="secondary"
-                sx={{
-                  textTransform: 'none',
-                  fontSize: '20px',
-                  fontWeight: 600,
-                  borderRadius: '6px'
-                }}
-                onClick={() => setOpenConfirmationDialog(true)}
-                disabled={Number(cnctAmount) === 0 || Number(formatTokenWithDecimals(totalRewards, cnctDecimals)) < rewards + 2000}
-              >
-                Stake now
-              </Button>
-            </Box>
-            {/* {Number(formatTokenWithDecimals(totalRewards, cnctDecimals)) < rewards + 2000 && 
+              </Box>
+              <Box>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  sx={{
+                    textTransform: 'none',
+                    fontSize: '20px',
+                    fontWeight: 600,
+                    borderRadius: '6px'
+                  }}
+                  onClick={() => setOpenConfirmationDialog(true)}
+                  disabled={Number(cnctAmount) === 0 || Number(formatTokenWithDecimals(totalRewards, cnctDecimals)) < rewards + 2000}
+                >
+                  Stake now
+                </Button>
+              </Box>
+              {/* {Number(formatTokenWithDecimals(totalRewards, cnctDecimals)) < rewards + 2000 && 
               <Typography sx={{ fontSize: '13px!important', mt: 2, textAlign: 'center', color: theme.palette.error.main }}>
                 The stake pool needs to be reloaded, please follow the announcements in Telegram or Discord for updates.
               </Typography>
             } */}
-          </DashboardCard>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={5} sx={{ display: 'flex', gap: 2, flexDirection: 'column' }}>
+            <DashboardCard>
+              <Box sx={{ width: '100%' }}>
+                <Box sx={{ mb: 2, textAlign: 'center' }}>
+                  <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                    Total APY
+                  </Typography>
+                  <Typography variant="h3" sx={{ fontWeight: 700 }}>
+                    {isLoading ?
+                      <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
+                      `${(calculateAPY(stakeDuration, (options.find(option => option.duration === stakeDuration)?.interest || 1))).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+                    }
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-around', width: '100%' }}>
+                  <Box sx={{ textAlign: 'center' }}>
+                    <Typography sx={{ fontWeight: 700 }}>
+                      Base APY
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                      {isLoading ?
+                        <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
+                        `${calculateAPY(1, (options.find(option => option.duration === 1)?.interest || 1)).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+                      }
+                    </Typography>
+                  </Box>
+                  <Box sx={{ textAlign: 'center' }}>
+                    <Typography sx={{ fontWeight: 700 }}>
+                      APY Boost
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                      {isLoading ?
+                        <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
+                        `${(calculateAPY(stakeDuration, (options.find(option => option.duration === stakeDuration)?.interest || 1)) - calculateAPY(1, (options.find(option => option.duration === 1)?.interest || 1))).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+                      }
+                    </Typography>
+                  </Box>
+                </Box>
+              </Box>
+            </DashboardCard>
+            <DashboardCard>
+              <DataSpread
+                title="Total Available Rewards"
+                data={`${formatNumber(parseFloat(formatTokenWithDecimals(totalRewards, cnctDecimals)), '')} CNCT`}
+                isLoading={isLoading}
+              />
+              <DataSpread
+                title="Unlock Date"
+                data={`${calculateFutureDateMonths(stakeDuration)}`}
+                isLoading={isLoading}
+              />
+              <DataSpread
+                title="Rewards"
+                data={`${rewards.toLocaleString(undefined, { maximumFractionDigits: 2 })} CNCT`}
+                isLoading={isLoading}
+              />
+              <DataSpread
+                title="Total interest"
+                data={`${((options.find(option => option.duration === stakeDuration)?.interest || 0) * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`}
+                isLoading={isLoading}
+              />
+            </DashboardCard>
+          </Grid>
         </Grid>
-        <Grid xs={12} md={5} sx={{ display: 'flex', gap: 2, flexDirection: 'column' }}>
-          <DashboardCard>
-            <Box sx={{ width: '100%' }}>
-              <Box sx={{ mb: 2, textAlign: 'center' }}>
-                <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                  Total APY
-                </Typography>
-                <Typography variant="h3" sx={{ fontWeight: 700 }}>
-                  {isLoading ?
-                    <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
-                    `${(calculateAPY(stakeDuration, (options.find(option => option.duration === stakeDuration)?.interest || 1))).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
-                  }
-                </Typography>
+      </Box >
+
+      <Box sx={{ mb: 4 }}>
+        <DashboardHeader title="Stake tiers" isDropdownHidden />
+        <Grid container spacing={2}>
+          <Grid xs={12} md={12} sx={{ display: 'flex', gap: 2 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 6</Typography>
               </Box>
-              <Box sx={{ display: 'flex', justifyContent: 'space-around', width: '100%' }}>
-                <Box sx={{ textAlign: 'center' }}>
-                  <Typography sx={{ fontWeight: 700 }}>
-                    Base APY
-                  </Typography>
-                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                    {isLoading ?
-                      <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
-                      `${calculateAPY(1, (options.find(option => option.duration === 1)?.interest || 1)).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
-                    }
-                  </Typography>
-                </Box>
-                <Box sx={{ textAlign: 'center' }}>
-                  <Typography sx={{ fontWeight: 700 }}>
-                    APY Boost
-                  </Typography>
-                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                    {isLoading ?
-                      <div style={{ display: "flex", justifyContent: "center" }}><Skeleton animation='wave' width={55} /></div> :
-                      `${(calculateAPY(stakeDuration, (options.find(option => option.duration === stakeDuration)?.interest || 1)) - calculateAPY(1, (options.find(option => option.duration === 1)?.interest || 1))).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
-                    }
-                  </Typography>
-                </Box>
-              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>1,500,000 $IDP</Typography>
+                <Typography>Seed Round with allocation capped at:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>10K USD</Typography>
+              </DashboardCard>
             </Box>
-          </DashboardCard>
-          <DashboardCard>
-            <DataSpread
-              title="Total Available Rewards"
-              data={`${formatNumber(parseFloat(formatTokenWithDecimals(totalRewards, cnctDecimals)), '')} CNCT`}
-              isLoading={isLoading}
-            />
-            <DataSpread
-              title="Unlock Date"
-              data={`${calculateFutureDateMonths(stakeDuration)}`}
-              isLoading={isLoading}
-            />
-            <DataSpread
-              title="Rewards"
-              data={`${rewards.toLocaleString(undefined, { maximumFractionDigits: 2 })} CNCT`}
-              isLoading={isLoading}
-            />
-            <DataSpread
-              title="Total interest"
-              data={`${((options.find(option => option.duration === stakeDuration)?.interest || 0) * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`}
-              isLoading={isLoading}
-            />
-          </DashboardCard>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 5</Typography>
+              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>700,000 $IDP</Typography>
+                <Typography>Private round with allocation capped at:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>2.5k USD</Typography>
+              </DashboardCard>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 4</Typography>
+              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>400,000 $IDP</Typography>
+                <Typography>Guaranteed allocation capped at:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>1.25K USD</Typography>
+              </DashboardCard>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 3</Typography>
+              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>150,000 $IDP</Typography>
+                <Typography>Guaranteed allocation capped at:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>600 USD</Typography>
+              </DashboardCard>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 2</Typography>
+              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>50,000 $IDP</Typography>
+                <Typography>Lottery-based allocation of up to:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>200 USD</Typography>
+              </DashboardCard>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
+                <Typography variant='h6'>TIER 1</Typography>
+              </Box>
+              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+                <Typography sx={{ fontWeight: 700 }}>25,000 $IDP</Typography>
+                <Typography>Lottery-based allocation of up to:</Typography>
+                <Typography sx={{ fontWeight: 900 }}>75 USD</Typography>
+              </DashboardCard>
+            </Box>
+          </Grid>
         </Grid>
-      </Grid>
+      </Box>
       <StakeConfirm
         open={openConfirmationDialog}
         setOpen={setOpenConfirmationDialog}
@@ -221,7 +295,7 @@ const AddStakePage: FC = () => {
         total={total}
         rewardIndex={rewardSettingIndex}
       />
-    </Box >
+    </>
   );
 };
 

--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -17,7 +17,6 @@ import React, { FC, useEffect, useMemo, useState } from 'react';
 import DashboardHeader from '../DashboardHeader';
 import StakeConfirm from '../staking/StakeConfirm';
 import StakeDuration from '../staking/StakeDuration';
-import { pink, orange, purple } from '@mui/material/colors';
 
 const options = [
   {
@@ -232,94 +231,128 @@ const AddStakePage: FC = () => {
           },
         }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
-              <Typography variant='h6'>TIER 6</Typography>
-            </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>1,500,000 $IDP</Typography>
-              <Typography>Seed Round with allocation capped at:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>10K USD</Typography>
-            </DashboardCard>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
-              <Typography variant='h6'>TIER 5</Typography>
-            </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>700,000 $IDP</Typography>
-              <Typography>Private round with allocation capped at:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>2.5k USD</Typography>
-            </DashboardCard>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
-              <Typography variant='h6'>TIER 4</Typography>
-            </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>400,000 $IDP</Typography>
-              <Typography>Guaranteed allocation capped at:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>1.25K USD</Typography>
-            </DashboardCard>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
-              <Typography variant='h6'>TIER 3</Typography>
-            </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>150,000 $IDP</Typography>
-              <Typography>Guaranteed allocation capped at:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>600 USD</Typography>
-            </DashboardCard>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
-              <Typography variant='h6'>TIER 2</Typography>
-            </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>50,000 $IDP</Typography>
-              <Typography>Lottery-based allocation of up to:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>200 USD</Typography>
-            </DashboardCard>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: theme.palette.primary.main, borderRadius: '6px' }}>
               <Typography variant='h6'>TIER 1</Typography>
             </Box>
-            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-              <Typography sx={{ fontWeight: 700 }}>25,000 $IDP</Typography>
-              <Typography>Lottery-based allocation of up to:</Typography>
-              <Typography sx={{ fontWeight: 900 }}>75 USD</Typography>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Initiate</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 5,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 80</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: theme.palette.primary.main, borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 2</Typography>
+            </Box>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Discoverer</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 10,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 200</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: '#c98e88', borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 3</Typography>
+            </Box>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Inovator</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 20,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 500</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: '#c98e88', borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 4</Typography>
+            </Box>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Expert</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 40,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 1,250</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: theme.palette.secondary.main, borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 5</Typography>
+            </Box>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Visionary</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 80,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 3,125</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: theme.palette.secondary.main, borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 6</Typography>
+            </Box>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)', justifyContent: 'center' }} center standard>
+              <Typography sx={{ fontWeight: 900 }}>Oracle</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Amount Staked: 160,000</Typography>
+              <Typography sx={{ fontWeight: 700 }}>Weight: 8,000</Typography>
             </DashboardCard>
           </Box>
         </Box>
       </Box>
-      <Box sx={{ mb: 4 }}>
+
+      <Box mb={4}>
         <DashboardHeader title="Learn more" isDropdownHidden />
-        <Box sx={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(2, 1fr)',
-          gap: 2,
-          '@media (min-width: 1280px)': {
-            gridTemplateColumns: 'repeat(4, 1fr)'
-          },
-        }}>
-          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            <Typography>How it works</Typography>
-            <Link component={'a'} target='_blank' href="https://docs.coinecta.fi/launchpad/how-it-works" sx={{ wordBreak: 'break-all' }}>https://docs.coinecta.fi/launchpad/how-it-works</Link>
-          </DashboardCard>
-          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            <Typography>Staking overview</Typography>
-            <Link component={'a'} target='_blank' href="https://docs.coinecta.fi/launchpad/staking" sx={{ wordBreak: 'break-all' }}>https://docs.coinecta.fi/launchpad/staking</Link>
-          </DashboardCard>
-          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            <Typography>How to stake</Typography>
-            <Link component={'a'} target='_blank' href="https://coinecta.medium.com/62ed3fb5dd21" sx={{ wordBreak: 'break-all' }}>https://coinecta.medium.com/62ed3fb5dd21</Link>
-          </DashboardCard>
-          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            <Typography>How to redeem</Typography>
-            <Link component={'a'} target='_blank' href="https://coinecta.medium.com/27ab254b4d33" sx={{ wordBreak: 'break-all' }}>https://coinecta.medium.com/27ab254b4d33</Link>
-          </DashboardCard>
-        </Box>
+        <Grid container spacing={2}>
+          <Grid xs={12} sm={6} md={3}>
+            <Button
+              href='https://docs.coinecta.fi/launchpad/how-it-works'
+              color='secondary'
+              variant='contained'
+              size='large'
+              target='_blank'
+              sx={{
+                width: '100%',
+                fontWeight: 700
+              }}>
+              How it works
+            </Button>
+          </Grid>
+          <Grid xs={12} sm={6} md={3}>
+            <Button
+              href='https://docs.coinecta.fi/launchpad/staking'
+              color='secondary'
+              variant='contained'
+              size='large'
+              target='_blank'
+              sx={{
+                width: '100%',
+                fontWeight: 700
+              }}>
+              Staking overview
+            </Button>
+          </Grid>
+          <Grid xs={12} sm={6} md={3}>
+            <Button
+              href='https://coinecta.medium.com/62ed3fb5dd21'
+              color='secondary'
+              variant='contained'
+              size='large'
+              target='_blank'
+              sx={{
+                width: '100%',
+                fontWeight: 700
+              }}>
+              How to stake
+            </Button>
+          </Grid>
+          <Grid xs={12} sm={6} md={3}>
+            <Button
+              href='https://coinecta.medium.com/27ab254b4d33'
+              color='secondary'
+              variant='contained'
+              size='large'
+              target='_blank'
+              sx={{
+                width: '100%',
+                fontWeight: 700
+              }}>
+              How to redeem
+            </Button>
+          </Grid>
+        </Grid>
       </Box>
       <StakeConfirm
         open={openConfirmationDialog}

--- a/src/components/dashboard/pages/AddStakePage.tsx
+++ b/src/components/dashboard/pages/AddStakePage.tsx
@@ -7,6 +7,7 @@ import { trpc } from '@lib/utils/trpc';
 import {
   Box,
   Button,
+  Link,
   Skeleton,
   Typography,
   useTheme
@@ -217,73 +218,108 @@ const AddStakePage: FC = () => {
           </Grid>
         </Grid>
       </Box >
-
       <Box sx={{ mb: 4 }}>
         <DashboardHeader title="Stake tiers" isDropdownHidden />
-        <Grid container spacing={2}>
-          <Grid xs={12} md={12} sx={{ display: 'flex', gap: 2 }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 6</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>1,500,000 $IDP</Typography>
-                <Typography>Seed Round with allocation capped at:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>10K USD</Typography>
-              </DashboardCard>
+        <Box sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 2,
+          '@media (min-width: 768px)': {
+            gridTemplateColumns: 'repeat(3, 1fr)'
+          },
+          '@media (min-width: 1280px)': {
+            gridTemplateColumns: 'repeat(6, 1fr)'
+          },
+        }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 6</Typography>
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 5</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>700,000 $IDP</Typography>
-                <Typography>Private round with allocation capped at:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>2.5k USD</Typography>
-              </DashboardCard>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>1,500,000 $IDP</Typography>
+              <Typography>Seed Round with allocation capped at:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>10K USD</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: pink[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 5</Typography>
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 4</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>400,000 $IDP</Typography>
-                <Typography>Guaranteed allocation capped at:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>1.25K USD</Typography>
-              </DashboardCard>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>700,000 $IDP</Typography>
+              <Typography>Private round with allocation capped at:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>2.5k USD</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 4</Typography>
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 3</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>150,000 $IDP</Typography>
-                <Typography>Guaranteed allocation capped at:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>600 USD</Typography>
-              </DashboardCard>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>400,000 $IDP</Typography>
+              <Typography>Guaranteed allocation capped at:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>1.25K USD</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: orange[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 3</Typography>
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 2</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>50,000 $IDP</Typography>
-                <Typography>Lottery-based allocation of up to:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>200 USD</Typography>
-              </DashboardCard>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>150,000 $IDP</Typography>
+              <Typography>Guaranteed allocation capped at:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>600 USD</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 2</Typography>
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
-              <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
-                <Typography variant='h6'>TIER 1</Typography>
-              </Box>
-              <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
-                <Typography sx={{ fontWeight: 700 }}>25,000 $IDP</Typography>
-                <Typography>Lottery-based allocation of up to:</Typography>
-                <Typography sx={{ fontWeight: 900 }}>75 USD</Typography>
-              </DashboardCard>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>50,000 $IDP</Typography>
+              <Typography>Lottery-based allocation of up to:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>200 USD</Typography>
+            </DashboardCard>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%', textAlign: 'center' }}>
+            <Box sx={{ textAlign: 'center', py: 1, px: 3, backgroundColor: purple[400], borderRadius: '6px' }}>
+              <Typography variant='h6'>TIER 1</Typography>
             </Box>
-          </Grid>
-        </Grid>
+            <DashboardCard sx={{ display: 'grid', gridTemplateRows: 'repeat(3, 1fr)' }} center>
+              <Typography sx={{ fontWeight: 700 }}>25,000 $IDP</Typography>
+              <Typography>Lottery-based allocation of up to:</Typography>
+              <Typography sx={{ fontWeight: 900 }}>75 USD</Typography>
+            </DashboardCard>
+          </Box>
+        </Box>
+      </Box>
+      <Box sx={{ mb: 4 }}>
+        <DashboardHeader title="Learn more" isDropdownHidden />
+        <Box sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 2,
+          '@media (min-width: 1280px)': {
+            gridTemplateColumns: 'repeat(4, 1fr)'
+          },
+        }}>
+          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+            <Typography>How it works</Typography>
+            <Link component={'a'} target='_blank' href="https://docs.coinecta.fi/launchpad/how-it-works" sx={{ wordBreak: 'break-all' }}>https://docs.coinecta.fi/launchpad/how-it-works</Link>
+          </DashboardCard>
+          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+            <Typography>Staking overview</Typography>
+            <Link component={'a'} target='_blank' href="https://docs.coinecta.fi/launchpad/staking" sx={{ wordBreak: 'break-all' }}>https://docs.coinecta.fi/launchpad/staking</Link>
+          </DashboardCard>
+          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+            <Typography>How to stake</Typography>
+            <Link component={'a'} target='_blank' href="https://coinecta.medium.com/62ed3fb5dd21" sx={{ wordBreak: 'break-all' }}>https://coinecta.medium.com/62ed3fb5dd21</Link>
+          </DashboardCard>
+          <DashboardCard sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+            <Typography>How to redeem</Typography>
+            <Link component={'a'} target='_blank' href="https://coinecta.medium.com/27ab254b4d33" sx={{ wordBreak: 'break-all' }}>https://coinecta.medium.com/27ab254b4d33</Link>
+          </DashboardCard>
+        </Box>
       </Box>
       <StakeConfirm
         open={openConfirmationDialog}

--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/router';
 import { FC, useEffect, useMemo, useState } from 'react';
 import DashboardCard from '../DashboardCard';
 import DashboardHeader from '../DashboardHeader';
+import { StakeData, StakeSnapshot } from '@server/services/syncApi';
 
 const Dashboard: FC = () => {
   const router = useRouter();
@@ -41,6 +42,13 @@ const Dashboard: FC = () => {
   const getRawUtxosMultiAddress = trpc.sync.getRawUtxosMultiAddress.useMutation();
   const getBalanceFromRawUtxos = trpc.sync.getBalanceFromRawUtxos.useMutation();
 
+  const queryStakeSnapshot = trpc.sync.getStakeSnapshot.useQuery(selectedAddresses, { retry: 0, refetchInterval: 5000 });
+  const snapshot = useMemo(() => queryStakeSnapshot.data, [queryStakeSnapshot.data]);
+
+  const userTotalWeight = useMemo(() => {
+    return snapshot?.data.reduce((totalWeight, { cummulativeWeight }) => totalWeight + cummulativeWeight ,0)
+  }, [snapshot])
+
   const summary = useMemo(() => {
     if (queryStakeSummary.data?.poolStats[STAKE_POOL_SUBJECT] === undefined) return undefined;
     return queryStakeSummary.data;
@@ -49,7 +57,7 @@ const Dashboard: FC = () => {
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded);
   }, [isStakingKeysLoaded, queryStakeSummary.isSuccess]);
-  
+
   const formatNumber = (num: number, key: string) => `${num.toLocaleString(undefined, {
     maximumFractionDigits: 2
   })}${key !== '' && key != null ? ` ${key}` : ''}`;
@@ -91,118 +99,223 @@ const Dashboard: FC = () => {
   const { cnctDecimals } = useToken();
 
   const formatWithDecimals = (value: string) => parseFloat(formatTokenWithDecimals(BigInt(value), cnctDecimals));
-  
+
   return (
-    <Box sx={{ position: 'relative' }} >
-      <DashboardHeader title="Overview" />
-      <Grid container spacing={2} sx={{ mb: 1 }}>
-        <Grid xs={12} md={5}>
-          <DashboardCard center>
-            <Typography>
-              Total portfolio value
-            </Typography>
-            <Typography variant="h5">
+    <>
+      <Box sx={{ mb: 4 }}>
+        <DashboardHeader title="CNCT Stake Stats" />
+        <Grid container spacing={2} sx={{ mb: 1 }}>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Typography>
+                Total Stakers
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(snapshot?.totalStakers ?? 0, '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Typography>
+                Total CNCT Staked
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(formatWithDecimals(snapshot?.totalStake ?? "0"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Typography>
+                Total Pool Weight
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(parseInt(snapshot?.totalCummulativeWeight ?? "0"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+        </Grid>
+      </Box>
+
+      <Box sx={{ position: 'relative' }} >
+        <DashboardHeader title="Overview" isDropdownHidden />
+        <Grid container spacing={2} sx={{ mb: 1 }}>
+          <Grid xs={12} md={5}>
+            <DashboardCard center>
+              <Typography>
+                Total portfolio value
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={7}>
+            <DashboardCard center>
+              <DataSpread
+                title="CNCT"
+                data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), '')}
+                usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}`}
+                isLoading={isLoading}
+              />
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Typography>
+                Total Vested
+              </Typography>
               {isLoading ?
-                <>
-                  <Skeleton animation='wave' width={160} />
-                  <Skeleton animation='wave' width={160} />
-                </> :
-                <>
-                  <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
-                  </Box>
-                </>
-              }
-            </Typography>
-          </DashboardCard>
-        </Grid>
-        <Grid xs={12} md={7}>
-          <DashboardCard center>
-            <DataSpread
-              title="CNCT"
-              data={formatNumber(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), '')}
-              usdValue={`$${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}`}
-              isLoading={isLoading}
-            />
-          </DashboardCard>
-        </Grid>
-        <Grid xs={12} md={4}>
-          <DashboardCard center>
-            <Typography>
-              Total Vested
-            </Typography>
-            {isLoading ?
-              <Box sx={{ mb: 1 }}>
-                <Skeleton animation='wave' width={100} />
-                <Skeleton animation='wave' width={100} />
-              </Box> :
-              <Box sx={{ mb: 1 }}>
-                <Typography align='center' variant='h5'>-</Typography>
-                <Typography sx={{ color: theme.palette.grey[500] }} align='center'>-</Typography>
-              </Box>}
-            <Button disabled variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/unlock-vested")}>
-              Unlock now
-            </Button>
-          </DashboardCard>
-        </Grid>
-        <Grid xs={12} md={4}>
-          <DashboardCard center>
-            <Box sx={{ display: 'flex', width: '100%', justifyContent: 'space-around', gap: '5px' }}>
-              <Box sx={{ flexGrow: '1' }}>
-                <Typography align='center'>Total Staked</Typography>
-                {isLoading ?
-                  <Box sx={{ mb: 1 }}>
-                    <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                    <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                  </Box> :
-                  <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0"), "CNCT"), '')}</Typography>
-                  </Box>}
-              </Box>
-              <Divider orientation='vertical' variant='middle' flexItem />
-              <Box sx={{ width: '50%' }}>
-                <Typography align='center'>Claimable Stake</Typography>
-                {isLoading ?
-                  <Box sx={{ mb: 1 }}>
-                    <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                    <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                  </Box> :
-                  <Box sx={{ mb: 1 }}>
-                    <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0")), '₳')}</Typography>
-                    <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
-                  </Box>}
-              </Box>
-            </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, width: '100%' }}>
-              <Button sx={{ margin: "auto" }} disabled={isLoading ? true : false} variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/manage-stake")}>
-                Manage positions
+                <Box sx={{ mb: 1 }}>
+                  <Skeleton animation='wave' width={100} />
+                  <Skeleton animation='wave' width={100} />
+                </Box> :
+                <Box sx={{ mb: 1 }}>
+                  <Typography align='center' variant='h5'>-</Typography>
+                  <Typography sx={{ color: theme.palette.grey[500] }} align='center'>-</Typography>
+                </Box>}
+              <Button disabled variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/unlock-vested")}>
+                Unlock now
               </Button>
-            </Box>
-          </DashboardCard>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Box sx={{ display: 'flex', width: '100%', justifyContent: 'space-around', gap: '5px' }}>
+                <Box sx={{ flexGrow: '1' }}>
+                  <Typography align='center'>Total Staked</Typography>
+                  {isLoading ?
+                    <Box sx={{ mb: 1 }}>
+                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
+                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
+                    </Box> :
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0")), '₳')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>}
+                </Box>
+                <Divider orientation='vertical' variant='middle' flexItem />
+                <Box sx={{ width: '50%' }}>
+                  <Typography align='center'>Claimable Stake</Typography>
+                  {isLoading ?
+                    <Box sx={{ mb: 1 }}>
+                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
+                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
+                    </Box> :
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0")), '₳')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].unclaimedTokens ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>}
+                </Box>
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, width: '100%' }}>
+                <Button sx={{ margin: "auto" }} disabled={isLoading ? true : false} variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/manage-stake")}>
+                  Manage positions
+                </Button>
+              </Box>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={4}>
+            <DashboardCard center>
+              <Typography>
+                Unclaimed tokens
+              </Typography>
+              {isLoading ?
+                <Box sx={{ mb: 1 }}>
+                  <Skeleton animation='wave' width={100} />
+                  <Skeleton animation='wave' width={100} />
+                </Box> :
+                <Box sx={{ mb: 1 }}>
+                  <Typography align='center' variant='h5'>-</Typography>
+                  <Typography sx={{ color: theme.palette.grey[500] }} align='center'>-</Typography>
+                </Box>}
+              <Button disabled variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/claim-tokens")}>
+                Claim now
+              </Button>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={6}>
+            <DashboardCard center>
+              <Typography>
+                Total Staked
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={6}>
+            <DashboardCard center>
+              <Typography>
+                Your Pool Weight
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{userTotalWeight}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
         </Grid>
-        <Grid xs={12} md={4}>
-          <DashboardCard center>
-            <Typography>
-              Unclaimed tokens
-            </Typography>
-            {isLoading ?
-              <Box sx={{ mb: 1 }}>
-                <Skeleton animation='wave' width={100} />
-                <Skeleton animation='wave' width={100} />
-              </Box> :
-              <Box sx={{ mb: 1 }}>
-                <Typography align='center' variant='h5'>-</Typography>
-                <Typography sx={{ color: theme.palette.grey[500] }} align='center'>-</Typography>
-              </Box>}
-            <Button disabled variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/claim-tokens")}>
-              Claim now
-            </Button>
-          </DashboardCard>
-        </Grid>
-      </Grid>
-    </Box>
+      </Box>
+    </>
   );
 };
 

--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -128,10 +128,12 @@ const Dashboard: FC = () => {
                 {isLoading ?
                   <>
                     <Skeleton animation='wave' width={160} />
+                    <Skeleton animation='wave' width={160} />
                   </> :
                   <>
                     <Box sx={{ mb: 1 }}>
                       <Typography align='center' variant='h5'>{formatNumber(formatWithDecimals(snapshot?.totalStake ?? "0"), '')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(snapshot?.totalStake ?? "0"), "CNCT"), '')}</Typography>
                     </Box>
                   </>
                 }
@@ -163,7 +165,7 @@ const Dashboard: FC = () => {
       <Box sx={{ position: 'relative' }} >
         <DashboardHeader title="Overview" isDropdownHidden />
         <Grid container spacing={2} sx={{ mb: 1 }}>
-          <Grid xs={12} md={5}>
+          <Grid xs={12} md={6}>
             <DashboardCard center>
               <Typography>
                 Total portfolio value
@@ -178,6 +180,46 @@ const Dashboard: FC = () => {
                     <Box sx={{ mb: 1 }}>
                       <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
                       <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={6}>
+            <DashboardCard center>
+              <Typography>
+                Total Staked
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
+                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
+                    </Box>
+                  </>
+                }
+              </Typography>
+            </DashboardCard>
+          </Grid>
+          <Grid xs={12} md={5}>
+            <DashboardCard center>
+              <Typography>
+                Your Pool Weight
+              </Typography>
+              <Typography variant="h5">
+                {isLoading ?
+                  <>
+                    <Skeleton animation='wave' width={160} />
+                  </> :
+                  <>
+                    <Box sx={{ mb: 1 }}>
+                      <Typography align='center' variant='h5'>{userTotalWeight}</Typography>
                     </Box>
                   </>
                 }
@@ -215,20 +257,7 @@ const Dashboard: FC = () => {
           </Grid>
           <Grid xs={12} md={4}>
             <DashboardCard center>
-              <Box sx={{ display: 'flex', width: '100%', justifyContent: 'space-around', gap: '5px' }}>
-                <Box sx={{ flexGrow: '1' }}>
-                  <Typography align='center'>Total Staked</Typography>
-                  {isLoading ?
-                    <Box sx={{ mb: 1 }}>
-                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                      <Skeleton sx={{ margin: 'auto' }} animation='wave' width={100} />
-                    </Box> :
-                    <Box sx={{ mb: 1 }}>
-                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0")), '₳')}</Typography>
-                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalStaked ?? "0"), "CNCT"), '')}</Typography>
-                    </Box>}
-                </Box>
-                <Divider orientation='vertical' variant='middle' flexItem />
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', width: '100%', gap: '5px' }}>
                 <Box sx={{ width: '50%' }}>
                   <Typography align='center'>Claimable Stake</Typography>
                   {isLoading ?
@@ -266,46 +295,6 @@ const Dashboard: FC = () => {
               <Button disabled variant="outlined" color="secondary" size="small" onClick={() => router.push("/dashboard/claim-tokens")}>
                 Claim now
               </Button>
-            </DashboardCard>
-          </Grid>
-          <Grid xs={12} md={6}>
-            <DashboardCard center>
-              <Typography>
-                Total Staked
-              </Typography>
-              <Typography variant="h5">
-                {isLoading ?
-                  <>
-                    <Skeleton animation='wave' width={160} />
-                    <Skeleton animation='wave' width={160} />
-                  </> :
-                  <>
-                    <Box sx={{ mb: 1 }}>
-                      <Typography align='center' variant='h5'>{formatNumber(convertCnctToADA(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT]?.totalPortfolio ?? "0")), '₳')}</Typography>
-                      <Typography sx={{ color: theme.palette.grey[500] }} align='center'>${formatNumber(convertToUSD(formatWithDecimals(summary?.poolStats[STAKE_POOL_SUBJECT].totalPortfolio ?? "0"), "CNCT"), '')}</Typography>
-                    </Box>
-                  </>
-                }
-              </Typography>
-            </DashboardCard>
-          </Grid>
-          <Grid xs={12} md={6}>
-            <DashboardCard center>
-              <Typography>
-                Your Pool Weight
-              </Typography>
-              <Typography variant="h5">
-                {isLoading ?
-                  <>
-                    <Skeleton animation='wave' width={160} />
-                  </> :
-                  <>
-                    <Box sx={{ mb: 1 }}>
-                      <Typography align='center' variant='h5'>{userTotalWeight}</Typography>
-                    </Box>
-                  </>
-                }
-              </Typography>
             </DashboardCard>
           </Grid>
         </Grid>

--- a/src/components/dashboard/pages/DashboardPage.tsx
+++ b/src/components/dashboard/pages/DashboardPage.tsx
@@ -19,7 +19,6 @@ import { useRouter } from 'next/router';
 import { FC, useEffect, useMemo, useState } from 'react';
 import DashboardCard from '../DashboardCard';
 import DashboardHeader from '../DashboardHeader';
-import { StakeData, StakeSnapshot } from '@server/services/syncApi';
 
 const Dashboard: FC = () => {
   const router = useRouter();
@@ -34,13 +33,9 @@ const Dashboard: FC = () => {
   const userWallets = useMemo(() => getWallets.data && getWallets.data.wallets, [getWallets]);
   const theme = useTheme();
 
-  const utils = trpc.useUtils();
   const queryStakeSummary = trpc.sync.getStakeSummary.useQuery(stakeKeys, { retry: 0, refetchInterval: 5000 });
 
   const STAKE_POOL_SUBJECT = process.env.STAKE_POOL_ASSET_POLICY! + process.env.STAKE_POOL_ASSET_NAME!;
-
-  const getRawUtxosMultiAddress = trpc.sync.getRawUtxosMultiAddress.useMutation();
-  const getBalanceFromRawUtxos = trpc.sync.getBalanceFromRawUtxos.useMutation();
 
   const queryStakeSnapshot = trpc.sync.getStakeSnapshot.useQuery(selectedAddresses, { retry: 0, refetchInterval: 5000 });
   const snapshot = useMemo(() => queryStakeSnapshot.data, [queryStakeSnapshot.data]);
@@ -52,7 +47,7 @@ const Dashboard: FC = () => {
   const summary = useMemo(() => {
     if (queryStakeSummary.data?.poolStats[STAKE_POOL_SUBJECT] === undefined) return undefined;
     return queryStakeSummary.data;
-  }, [queryStakeSummary.data]);
+  }, [queryStakeSummary.data, STAKE_POOL_SUBJECT]);
 
   useEffect(() => {
     setIsLoading(!queryStakeSummary.isSuccess || !isStakingKeysLoaded);

--- a/src/server/routers/sync.ts
+++ b/src/server/routers/sync.ts
@@ -13,6 +13,11 @@ export const syncRouter = createTRPCRouter({
     .query(async ({ input }) => {
       return await coinectaSyncApi.getStakePositions(input);
     }),
+  getStakeSnapshot: protectedProcedure
+    .input(z.array(z.string()))
+    .query(async ({ input }) => {
+      return await coinectaSyncApi.getStakeSnapshot(input);
+    }),
   getStakePool: protectedProcedure
     .input(z.object({
       address: z.string(),

--- a/src/server/services/syncApi.ts
+++ b/src/server/services/syncApi.ts
@@ -127,6 +127,20 @@ export type ClaimStakeRequest = {
   changeAddress: string;
 };
 
+export interface StakeData {
+  address: string;
+  uniqueNfts: number;
+  totalStake: string;
+  cummulativeWeight: number;
+}
+
+export type StakeSnapshot = {
+  data: StakeData[];
+  totalCummulativeWeight: string;
+  totalStake: string;
+  totalStakers: number;
+}
+
 export const coinectaSyncApi = {
   async getStakeSummary(stakeKeys: string[]): Promise<StakeSummary | null> {
     try {
@@ -149,6 +163,23 @@ export const coinectaSyncApi = {
     try {
       if (stakeKeys.length === 0) return [];
       const response = await syncApi.post("/stake/positions", stakeKeys);
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        throw mapAxiosErrorToTRPCError(error);
+      } else {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unknown error occurred",
+        });
+      }
+    }
+  },
+  async getStakeSnapshot(addresses: string[]): Promise<StakeSnapshot | null> {
+    try {
+      if (addresses.length === 0) return null;
+      const response = await syncApi.post("/stake/snapshot", addresses);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {


### PR DESCRIPTION
This PR introduces these changes:

## Overview Page
- Added 'CNCT Stake Stats' section that displays the number of total stakers, total CNCT staked, and the total pool weight
- Added 'Your pool weight' info
- Rearranged the positions of some information

![localhost_8181_dashboard(1440) (1)](https://github.com/coinecta/coinecta-frontend/assets/81457844/aa980b8b-a56a-4f07-8617-a9278e013881)

## Add Stake Page
- Added 'Stake tiers' and 'Learn more' sections

![localhost_8181_dashboard(1440) (2)](https://github.com/coinecta/coinecta-frontend/assets/81457844/c4a22565-fc7e-42e8-aee3-2341bd94dd93)

This PR closes issue #99